### PR TITLE
Rename to matrix-sdk-crypto-wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrix-sdk-crypto-js"
+name = "matrix-sdk-crypto-wasm"
 version = "0.1.0-alpha.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "matrix-sdk-crypto-js"
+name = "matrix-sdk-crypto-wasm"
 description = "Matrix encryption library, for JavaScript"
 authors = ["Ivan Enderlin <ivane@element.io>"]
 edition = "2021"
-homepage = "https://github.com/matrix-org/matrix-rust-sdk"
+homepage = "https://github.com/matrix-org/matrix-rust-sdk-wasm"
 keywords = ["matrix", "chat", "messaging", "ruma", "nio"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/matrix-org/matrix-rust-sdk"
+repository = "https://github.com/matrix-org/matrix-rust-sdk-wasm"
 rust-version = "1.70"
-version = "0.1.0-alpha.0"
+version = "0.0.0"
 publish = false
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `matrix-sdk-crypto-js`
+# `matrix-sdk-crypto-wasm`
 
 Welcome to the [WebAssembly] + JavaScript binding for the Rust
 [`matrix-sdk-crypto`] library! WebAssembly can run anywhere, but these
@@ -38,7 +38,7 @@ TBD
 ## Documentation
 
 [The documentation can be found
-online](https://matrix-org.github.io/matrix-rust-sdk-crypto-web/).
+online](https://matrix-org.github.io/matrix-rust-sdk-crypto-wasm/).
 
 To generate the documentation locally, please run the following
 command:

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-    "name": "@matrix-org/matrix-sdk-crypto-js",
+    "name": "@matrix-org/matrix-sdk-crypto-wasm",
     "version": "0.1.4",
-    "homepage": "https://github.com/matrix-org/matrix-rust-sdk",
-    "description": "Matrix encryption library, for JavaScript",
+    "homepage": "https://github.com/matrix-org/matrix-rust-sdk-wasm",
+    "description": "WebAssembly bindings of the matrix-sdk-crypto encryption library",
     "license": "Apache-2.0",
     "collaborators": [
         "Ivan Enderlin <ivane@element.io>"
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/matrix-org/matrix-rust-sdk"
+        "url": "https://github.com/matrix-org/matrix-rust-sdk-wasm"
     },
     "keywords": [
         "matrix",
@@ -18,13 +18,13 @@
         "ruma",
         "nio"
     ],
-    "main": "pkg/matrix_sdk_crypto_js.js",
-    "types": "pkg/matrix_sdk_crypto_js.d.ts",
+    "main": "pkg/matrix_sdk_crypto_wasm.js",
+    "types": "pkg/matrix_sdk_crypto_wasm.d.ts",
     "files": [
-        "pkg/matrix_sdk_crypto_js_bg.wasm.js",
-        "pkg/matrix_sdk_crypto_js_bg.wasm.d.ts",
-        "pkg/matrix_sdk_crypto_js.js",
-        "pkg/matrix_sdk_crypto_js.d.ts"
+        "pkg/matrix_sdk_crypto_wasm_bg.wasm.js",
+        "pkg/matrix_sdk_crypto_wasm_bg.wasm.d.ts",
+        "pkg/matrix_sdk_crypto_wasm.js",
+        "pkg/matrix_sdk_crypto_wasm.d.ts"
     ],
     "devDependencies": {
         "cross-env": "^7.0.3",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,19 +21,19 @@ RUSTFLAGS='-C opt-level=z' WASM_BINDGEN_WEAKREF=1 wasm-pack build --target nodej
 # Convert the Wasm into a JS file that exports the base64'ed Wasm.
 {
   printf 'module.exports = `'
-  base64 < pkg/matrix_sdk_crypto_js_bg.wasm
+  base64 < pkg/matrix_sdk_crypto_wasm_bg.wasm
   printf '`;'
-} > pkg/matrix_sdk_crypto_js_bg.wasm.js
+} > pkg/matrix_sdk_crypto_wasm_bg.wasm.js
 
 # In the JavaScript:
 #  1. Strip out the lines that load the WASM, and our new epilogue.
 #  2. Remove the imports of `TextDecoder` and `TextEncoder`. We rely on the global defaults.
 {
   sed -e '/Text..coder.*= require(.util.)/d' \
-      -e '/^const path = /,$d' pkg/matrix_sdk_crypto_js.js
+      -e '/^const path = /,$d' pkg/matrix_sdk_crypto_wasm.js
   cat scripts/epilogue.js
-} > pkg/matrix_sdk_crypto_js.js.new
-mv pkg/matrix_sdk_crypto_js.js.new pkg/matrix_sdk_crypto_js.js
+} > pkg/matrix_sdk_crypto_wasm.js.new
+mv pkg/matrix_sdk_crypto_wasm.js.new pkg/matrix_sdk_crypto_wasm.js
 
 # also extend the typescript
-cat scripts/epilogue.d.ts >> pkg/matrix_sdk_crypto_js.d.ts
+cat scripts/epilogue.d.ts >> pkg/matrix_sdk_crypto_wasm.d.ts

--- a/scripts/epilogue.js
+++ b/scripts/epilogue.js
@@ -17,7 +17,7 @@ const __initSync = function () {
     if (initPromise) {
         throw new Error("Asynchronous initialisation already in progress: cannot initialise synchronously");
     }
-    const bytes = unbase64(require("./matrix_sdk_crypto_js_bg.wasm.js"));
+    const bytes = unbase64(require("./matrix_sdk_crypto_wasm_bg.wasm.js"));
     const mod = new WebAssembly.Module(bytes);
     const instance = new WebAssembly.Instance(mod, imports);
     wasm = instance.exports;
@@ -41,7 +41,7 @@ module.exports.initAsync = function () {
     }
     if (!initPromise) {
         initPromise = Promise.resolve()
-            .then(() => require("./matrix_sdk_crypto_js_bg.wasm.js"))
+            .then(() => require("./matrix_sdk_crypto_wasm_bg.wasm.js"))
             .then((b64) => WebAssembly.instantiate(unbase64(b64), imports))
             .then((result) => {
                 wasm = result.instance.exports;

--- a/tests/asyncload.test.js
+++ b/tests/asyncload.test.js
@@ -1,4 +1,4 @@
-const { UserId, initAsync } = require("../pkg/matrix_sdk_crypto_js");
+const { UserId, initAsync } = require("../pkg/matrix_sdk_crypto_wasm");
 
 test("can instantiate rust objects with async initialiser", async () => {
     initUserId = () => new UserId("@foo:bar.org");

--- a/tests/attachment.test.js
+++ b/tests/attachment.test.js
@@ -1,4 +1,4 @@
-const { Attachment, EncryptedAttachment } = require("../pkg/matrix_sdk_crypto_js");
+const { Attachment, EncryptedAttachment } = require("../pkg/matrix_sdk_crypto_wasm");
 
 describe(Attachment.name, () => {
     const originalData = "hello";

--- a/tests/device.test.js
+++ b/tests/device.test.js
@@ -25,7 +25,7 @@ const {
     Qr,
     QrCode,
     QrCodeScan,
-} = require("../pkg/matrix_sdk_crypto_js");
+} = require("../pkg/matrix_sdk_crypto_wasm");
 const { zip, addMachineToMachine } = require("./helper");
 const { VerificationRequestPhase, QrState } = require("../pkg");
 

--- a/tests/encryption.test.js
+++ b/tests/encryption.test.js
@@ -3,7 +3,7 @@ const {
     EncryptionSettings,
     HistoryVisibility,
     VerificationState,
-} = require("../pkg/matrix_sdk_crypto_js");
+} = require("../pkg/matrix_sdk_crypto_wasm");
 
 describe("EncryptionAlgorithm", () => {
     test("has the correct variant values", () => {

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -1,4 +1,4 @@
-const { HistoryVisibility } = require("../pkg/matrix_sdk_crypto_js");
+const { HistoryVisibility } = require("../pkg/matrix_sdk_crypto_wasm");
 
 describe("HistoryVisibility", () => {
     test("has the correct variant values", () => {

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -1,4 +1,4 @@
-const { DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest } = require("../pkg/matrix_sdk_crypto_js");
+const { DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest } = require("../pkg/matrix_sdk_crypto_wasm");
 
 function* zip(...arrays) {
     const len = Math.min(...arrays.map((array) => array.length));

--- a/tests/identifiers.test.js
+++ b/tests/identifiers.test.js
@@ -7,7 +7,7 @@ const {
     RoomId,
     ServerName,
     UserId,
-} = require("../pkg/matrix_sdk_crypto_js");
+} = require("../pkg/matrix_sdk_crypto_wasm");
 
 describe(UserId.name, () => {
     test("cannot be invalid", () => {

--- a/tests/machine.test.js
+++ b/tests/machine.test.js
@@ -24,7 +24,7 @@ const {
     VerificationState,
     Versions,
     getVersions,
-} = require("../pkg/matrix_sdk_crypto_js");
+} = require("../pkg/matrix_sdk_crypto_wasm");
 const { addMachineToMachine } = require("./helper");
 require("fake-indexeddb/auto");
 

--- a/tests/requests.test.js
+++ b/tests/requests.test.js
@@ -7,7 +7,7 @@ const {
     SignatureUploadRequest,
     RoomMessageRequest,
     KeysBackupRequest,
-} = require("../pkg/matrix_sdk_crypto_js");
+} = require("../pkg/matrix_sdk_crypto_wasm");
 
 describe("RequestType", () => {
     test("has the correct variant values", () => {

--- a/tests/sync_events.test.js
+++ b/tests/sync_events.test.js
@@ -1,4 +1,4 @@
-const { DeviceLists, UserId } = require("../pkg/matrix_sdk_crypto_js");
+const { DeviceLists, UserId } = require("../pkg/matrix_sdk_crypto_wasm");
 
 describe(DeviceLists.name, () => {
     test("can be empty", () => {

--- a/tests/tracing.test.js
+++ b/tests/tracing.test.js
@@ -1,4 +1,4 @@
-const { Tracing, LoggerLevel, OlmMachine, UserId, DeviceId } = require("../pkg/matrix_sdk_crypto_js");
+const { Tracing, LoggerLevel, OlmMachine, UserId, DeviceId } = require("../pkg/matrix_sdk_crypto_wasm");
 
 describe("LoggerLevel", () => {
     test("has the correct variant values", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "strict": true
     },
     "typedocOptions": {
-        "entryPoints": ["pkg/matrix_sdk_crypto_js.d.ts"],
+        "entryPoints": ["pkg/matrix_sdk_crypto_wasm.d.ts"],
         "out": "docs",
         "readme": "README.md"
     }


### PR DESCRIPTION
Since we're moving everything around anyway, let's take the opportunity to rename the project to matrix-sdk-crypto-wasm to better distinguish it from matrix-sdk-crypto-nodejs.