### PR TITLE
Release v1.0.0

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,0 @@
-version-tag-prefix "matrix-sdk-crypto-js-"
-version-git-message "matrix-sdk-crypto-js v%s"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-# v0.1.4
+# matrix-sdk-crypto-wasm v1.0.0
+
+Project renamed to `matrix-sdk-crypto-wasm`. No functional changes.
+
+# matrix-sdk-crypto-js v0.1.4
 
 -   Add method `OlmMachine.queryKeysForUsers` to build an out-of-band key
     request.
 
-# v0.1.3
+# matrix-sdk-crypto-js v0.1.3
 
 ## Changes in the Javascript bindings
 
@@ -13,7 +17,7 @@
 
 -   Fix a bug which could cause generated one-time-keys not to be persisted.
 
-# v0.1.2
+# matrix-sdk-crypto-js v0.1.2
 
 **WARNING**: this version had a breaking change in the result type of `OlmMachine.receiveSyncChanges`.
 This is corrected in v0.1.3.
@@ -27,11 +31,11 @@ This is corrected in v0.1.3.
 
 -   Fix handling of SAS verification start events once we have shown a QR code.
 
-# v0.1.1
+# matrix-sdk-crypto-js v0.1.1
 
 -   Add `verify` method to `Device`.
 
-# v0.1.0
+# matrix-sdk-crypto-js v0.1.0
 
 ## Changes in the Javascript bindings
 
@@ -46,7 +50,7 @@ This is corrected in v0.1.3.
     `m.key.verification.cancel` to the device that made the request, rather
     than broadcasting to all devices.
 
-# v0.1.0-alpha.11
+# matrix-sdk-crypto-js v0.1.0-alpha.11
 
 ## Changes in the Javascript bindings
 
@@ -62,11 +66,11 @@ This is corrected in v0.1.3.
 -   Ensure that the correct short authentication strings are used when accepting a
     SAS verification with the `Sas::accept()` method.
 
-# v0.1.0-alpha.10
+# matrix-sdk-crypto-js v0.1.0-alpha.10
 
 -   Add `masterKey`, `userSigningKey`, `selfSigningKey` to `UserIdentity` and `OwnUserIdentity`
 
-# v0.1.0-alpha.9
+# matrix-sdk-crypto-js v0.1.0-alpha.9
 
 -   Extend `OlmDevice.markRequestAsSent` to accept responses to
     `SigningKeysUploadRequest`s.
@@ -75,19 +79,19 @@ This is corrected in v0.1.3.
 -   Fix the body of `SignatureUploadRequest`s to match the spec.
 -   Add a constructor for `SigningKeysUploadRequest`.
 
-# v0.1.0-alpha.8
+# matrix-sdk-crypto-js v0.1.0-alpha.8
 
 -   `importCrossSigningKeys`: change the parameters to be individual keys
     rather than a `CrossSigningKeyExport` object.
 -   Make `unused_fallback_keys` optional in `Machine.receive_sync_changes`
 
-# v0.1.0-alpha.7
+# matrix-sdk-crypto-js v0.1.0-alpha.7
 
 -   Add new accessors `Device.algorithms` and `Device.isSignedByOwner`
 -   In `OlmMachine.getUserDevices`, wait a limited time for any in-flight
     device-list updates to complete.
 
-# v0.1.0-alpha.6
+# matrix-sdk-crypto-js v0.1.0-alpha.6
 
 -   Add new accessor `InboundGroupSession.senderKey`.
 -   Add a new API, `OlmMachine.registerRoomKeyUpdatedCallback`, which

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,13 +1,15 @@
-# Steps for releasing `matrix-sdk-crypto-js`
+# Steps for releasing `matrix-sdk-crypto-wasm`
 
-1. Create a new branch, named `release-matrix-sdk-crypto-js-<version>`.
+1. Create a new branch, named `release-v<version>`.
 2. Update `CHANGELOG.md`, if necessary.
 3. Run `yarn version` to bump the version number and create a tag.
 4. Push the branch, but not yet the tag.
 5. Create a PR to approve the changes.
 6. Once approved:
     1. Update the git tag to the new head of the branch, if necessary.
-    2. Push the git tag; doing so triggers the github actions workflow which
-       builds and publishes to npm, and creates a draft GH release.
-    3. Merge the PR.
+    2. Push the git tag (`git push origin tag v<version>`). Doing so triggers
+       the github actions workflow which builds and publishes to npm, and
+       creates a draft GH release.
+    3. Merge the PR. (Prefer a genuine merge rather than a squash so that
+       the tagged commit is included in the history.)
 7. Update the release on github and publish.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-wasm",
-    "version": "0.1.4",
+    "version": "1.0.0",
     "homepage": "https://github.com/matrix-org/matrix-rust-sdk-wasm",
     "description": "WebAssembly bindings of the matrix-sdk-crypto encryption library",
     "license": "Apache-2.0",


### PR DESCRIPTION
Ensure we have a relesed version of matrix-sdk-crypto-wasm to point to.

This also updates the format of the release branch and tag names to be more conventional.