### PR TITLE
GHA release workflow: fix permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Create the Github release
         uses: softprops/action-gh-release@v1
+        permissions:
+          contents: write
         with:
           draft: true
-          files: pkg/matrix-org-matrix-sdk-crypto-js-*.tgz


### PR DESCRIPTION
Our new repo does not give write permissions by default. This is a good thing.