### PR TITLE
doc(readme): Fix typo in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Encryption](https://en.wikipedia.org/wiki/End-to-end_encryption)) for
         // The following will use an in-memory store. It is recommended to use
         // indexedDB where that is available.
         // See https://matrix-org.github.io/matrix-rust-sdk-crypto-wasm/classes/OlmMachine.html#initialize
-        const olmMachine = await RustSdkCryptoJs.OlmMachine.initialize(
+        const olmMachine = await matrixSdkCrypto.OlmMachine.initialize(
             new RustSdkCryptoJs.UserId(userId),
             new RustSdkCryptoJs.DeviceId(deviceId),
         );


### PR DESCRIPTION
I've noticed a typo in an example of the `README.md`.