### PR TITLE
Add `BackupKeys.decryptionKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# unreleased
+
+## Changes in the WASM bindings
+
+-   The `BackupKeys` structure returned by `OlmMachine.getBackupKeys` now
+    contains a `decryptionKey` property which is is a `BackupDecryptionKey`
+    instance.
+
 # matrix-sdk-crypto-wasm v1.1.0
 
 ## Changes in the WASM bindings

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -3,13 +3,17 @@
 use js_sys::JsString;
 use matrix_sdk_crypto::{backups::MegolmV1BackupKey as InnerMegolmV1BackupKey, store};
 use wasm_bindgen::prelude::*;
+use crate::impl_from_to_inner;
 
 /// The private part of the backup key, the one used for recovery.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[wasm_bindgen]
 pub struct BackupDecryptionKey {
     pub(crate) inner: store::BackupDecryptionKey,
 }
+
+impl_from_to_inner!(store::BackupDecryptionKey => BackupDecryptionKey);
+
 
 /// The public part of the backup key.
 #[derive(Debug, Clone)]
@@ -103,10 +107,22 @@ impl From<matrix_sdk_crypto::store::RoomKeyCounts> for RoomKeyCounts {
 #[derive(Debug)]
 #[wasm_bindgen]
 pub struct BackupKeys {
-    /// The key used to decrypt backed up room keys, encoded as base64
-    #[wasm_bindgen(js_name = "decryptionKeyBase64", getter_with_clone)]
-    pub decryption_key_base64: Option<String>,
+    /// The key used to decrypt backed up room keys
+    #[wasm_bindgen(js_name = "decryptionKey", getter_with_clone)]
+    pub decryption_key: Option<BackupDecryptionKey>,
+
     /// The version that we are using for backups.
     #[wasm_bindgen(js_name = "backupVersion", getter_with_clone)]
     pub backup_version: Option<String>,
+}
+
+#[wasm_bindgen]
+impl BackupKeys {
+    /// The key used to decrypt backed up room keys, encoded as base64
+    ///
+    /// @deprecated Use `BackupKeys.decryptionKey.toBase64()`
+    #[wasm_bindgen(js_name = "decryptionKeyBase64", getter)]
+    pub fn decryption_key_base64(&self) -> Option<JsString> {
+        self.decryption_key.clone().map(|k| k.to_base64())
+    }
 }

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -3,6 +3,7 @@
 use js_sys::JsString;
 use matrix_sdk_crypto::{backups::MegolmV1BackupKey as InnerMegolmV1BackupKey, store};
 use wasm_bindgen::prelude::*;
+
 use crate::impl_from_to_inner;
 
 /// The private part of the backup key, the one used for recovery.
@@ -13,7 +14,6 @@ pub struct BackupDecryptionKey {
 }
 
 impl_from_to_inner!(store::BackupDecryptionKey => BackupDecryptionKey);
-
 
 /// The public part of the backup key.
 #[derive(Debug, Clone)]

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -816,7 +816,7 @@ impl OlmMachine {
         future_to_promise(async move {
             let inner = me.backup_machine().get_backup_keys().await?;
             Ok(BackupKeys {
-                decryption_key_base64: inner.decryption_key.map(|k| k.to_base64()),
+                decryption_key: inner.decryption_key.map(|k| k.clone().into()),
                 backup_version: inner.backup_version,
             })
         })

--- a/tests/machine.test.js
+++ b/tests/machine.test.js
@@ -1026,6 +1026,7 @@ describe(OlmMachine.name, () => {
 
             let savedKey = await m.getBackupKeys();
 
+            expect(savedKey.decryptionKey.toBase64()).toStrictEqual(keyBackupKey.toBase64());
             expect(savedKey.decryptionKeyBase64).toStrictEqual(keyBackupKey.toBase64());
             expect(savedKey.backupVersion).toStrictEqual("3");
         });


### PR DESCRIPTION
Return an actual `BackupDecryptionKey` in tthe `BackupKeys` structure, rather than just the base64.

This is more symmetrical with `saveBackupDecryptionKey`, and also allows the public key to be extracted, which is useful sometimes.