### PR TITLE
feat: Add `future_to_promise_with_custom_error`

### DIFF
--- a/src/future.rs
+++ b/src/future.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 
+use futures_util::TryFutureExt;
 use js_sys::Promise;
 use wasm_bindgen::{JsError, JsValue, UnwrapThrowExt};
 use wasm_bindgen_futures::spawn_local;
@@ -9,6 +10,15 @@ where
     F: Future<Output = Result<T, anyhow::Error>> + 'static,
     T: Into<JsValue>,
 {
+    future_to_promise_with_custom_error(future.map_err(|error| JsError::new(&error.to_string())))
+}
+
+pub(crate) fn future_to_promise_with_custom_error<F, T, E>(future: F) -> Promise
+where
+    F: Future<Output = Result<T, E>> + 'static,
+    T: Into<JsValue>,
+    E: Into<JsValue>,
+{
     let mut future = Some(future);
 
     Promise::new(&mut |resolve, reject| {
@@ -17,9 +27,7 @@ where
         spawn_local(async move {
             match future.await {
                 Ok(value) => resolve.call1(&JsValue::UNDEFINED, &value.into()).unwrap_throw(),
-                Err(value) => reject
-                    .call1(&JsValue::UNDEFINED, &JsError::new(&value.to_string()).into())
-                    .unwrap_throw(),
+                Err(value) => reject.call1(&JsValue::UNDEFINED, &value.into()).unwrap_throw(),
             };
         });
     })


### PR DESCRIPTION
This patch implements `future_to_promise_with_custom_error`. It allows a `Future` to return a `JsValue` for the error, instead of returning a `JsError` directly. It provides more flexibility to return any kind of error types.