### PR TITLE
Add detailed megolm decryption errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -56,10 +56,7 @@ impl From<MegolmError> for MegolmDecryptionError {
                     .as_ref()
                     .map(|code| code.to_string().to_owned().into()),
             },
-            MegolmError::Decryption(vodozemac::megolm::DecryptionError::UnknownMessageIndex(
-                _,
-                _,
-            )) => MegolmDecryptionError {
+            MegolmError::Decryption(vodozemac::megolm::DecryptionError::UnknownMessageIndex(..))) => MegolmDecryptionError {
                 code: DecryptionErrorCode::UnknownMessageIndex,
                 description: value.to_string().into(),
                 maybe_withheld: None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 //! Errors related to room event decryption.
 
 use js_sys::JsString;
-use matrix_sdk_crypto::{MegolmError, vodozemac};
+use matrix_sdk_crypto::{vodozemac, MegolmError};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 /// Decryption error codes
@@ -17,7 +17,7 @@ pub enum DecryptionErrorCode {
     /// the plaintext of the room key to-device message.
     MismatchedIdentityKeys,
     /// Other failuer
-    UnableToDecrypt
+    UnableToDecrypt,
 }
 
 /// Js Decryption error with code.
@@ -41,44 +41,44 @@ impl MegolmDecryptionError {
         Self {
             code: DecryptionErrorCode::UnableToDecrypt,
             description: desc.into(),
-            maybe_withheld: None
+            maybe_withheld: None,
         }
     }
 }
 
-
 impl From<MegolmError> for MegolmDecryptionError {
-
     fn from(value: MegolmError) -> Self {
         match &value {
-            MegolmError::MissingRoomKey(withheld_code) => {
-                MegolmDecryptionError {
-                    code: DecryptionErrorCode::MissingRoomKey,
-                    description: value.to_string().into(),
-                    maybe_withheld: withheld_code.as_ref().map(|code| code.to_string().to_owned().into()),
-                }
-            }
-            MegolmError::Decryption(vodozemac::megolm::DecryptionError::UnknownMessageIndex(_,_)) => {
-                MegolmDecryptionError {
-                    code: DecryptionErrorCode::UnknownMessageIndex,
-                    description: value.to_string().into(),
-                    maybe_withheld: None
-                }
-            }
-            MegolmError::MismatchedIdentityKeys { key_ed25519: _, device_ed25519: _, key_curve25519: _, device_curve25519: _ } => {
-                MegolmDecryptionError { 
-                    code: DecryptionErrorCode::UnknownMessageIndex,
-                    description: value.to_string().into(),
-                    maybe_withheld: None
-                }
-            }
-            _ => {
-                MegolmDecryptionError { 
-                    code: DecryptionErrorCode::UnableToDecrypt,
-                    description: value.to_string().into(),
-                    maybe_withheld: None
-                }
-            }
+            MegolmError::MissingRoomKey(withheld_code) => MegolmDecryptionError {
+                code: DecryptionErrorCode::MissingRoomKey,
+                description: value.to_string().into(),
+                maybe_withheld: withheld_code
+                    .as_ref()
+                    .map(|code| code.to_string().to_owned().into()),
+            },
+            MegolmError::Decryption(vodozemac::megolm::DecryptionError::UnknownMessageIndex(
+                _,
+                _,
+            )) => MegolmDecryptionError {
+                code: DecryptionErrorCode::UnknownMessageIndex,
+                description: value.to_string().into(),
+                maybe_withheld: None,
+            },
+            MegolmError::MismatchedIdentityKeys {
+                key_ed25519: _,
+                device_ed25519: _,
+                key_curve25519: _,
+                device_curve25519: _,
+            } => MegolmDecryptionError {
+                code: DecryptionErrorCode::UnknownMessageIndex,
+                description: value.to_string().into(),
+                maybe_withheld: None,
+            },
+            _ => MegolmDecryptionError {
+                code: DecryptionErrorCode::UnableToDecrypt,
+                description: value.to_string().into(),
+                maybe_withheld: None,
+            },
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,7 +56,9 @@ impl From<MegolmError> for MegolmDecryptionError {
                     .as_ref()
                     .map(|code| code.to_string().to_owned().into()),
             },
-            MegolmError::Decryption(vodozemac::megolm::DecryptionError::UnknownMessageIndex(..))) => MegolmDecryptionError {
+            MegolmError::Decryption(vodozemac::megolm::DecryptionError::UnknownMessageIndex(
+                ..,
+            )) => MegolmDecryptionError {
                 code: DecryptionErrorCode::UnknownMessageIndex,
                 description: value.to_string().into(),
                 maybe_withheld: None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,12 +61,7 @@ impl From<MegolmError> for MegolmDecryptionError {
                 description: value.to_string().into(),
                 maybe_withheld: None,
             },
-            MegolmError::MismatchedIdentityKeys {
-                key_ed25519: _,
-                device_ed25519: _,
-                key_curve25519: _,
-                device_curve25519: _,
-            } => MegolmDecryptionError {
+            MegolmError::MismatchedIdentityKeys { .. } => MegolmDecryptionError {
                 code: DecryptionErrorCode::UnknownMessageIndex,
                 description: value.to_string().into(),
                 maybe_withheld: None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,84 @@
+//! Errors related to room event decryption.
+
+use js_sys::JsString;
+use matrix_sdk_crypto::{MegolmError, vodozemac};
+use wasm_bindgen::prelude::wasm_bindgen;
+
+/// Decryption error codes
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy)]
+pub enum DecryptionErrorCode {
+    /// The room key is not known
+    MissingRoomKey,
+    /// The room key is known but ratcheted
+    UnknownMessageIndex,
+    /// Decryption failed because of a mismatch between the identity keys of the
+    /// device we received the room key from and the identity keys recorded in
+    /// the plaintext of the room key to-device message.
+    MismatchedIdentityKeys,
+    /// Other failuer
+    UnableToDecrypt
+}
+
+/// Js Decryption error with code.
+#[derive(Debug)]
+#[wasm_bindgen(getter_with_clone)]
+pub struct MegolmDecryptionError {
+    /// Description code for the error. See `DecryptionErrorCode`
+    #[wasm_bindgen(readonly)]
+    pub code: DecryptionErrorCode,
+    /// detailed description
+    #[wasm_bindgen(readonly)]
+    pub description: JsString,
+    /// Witheld code if any. Only for `UnknownMessageIndex` error code
+    #[wasm_bindgen(readonly)]
+    pub maybe_withheld: Option<JsString>,
+}
+
+impl MegolmDecryptionError {
+    /// Creates generic error with description
+    pub fn unable_to_decrypt(desc: String) -> Self {
+        Self {
+            code: DecryptionErrorCode::UnableToDecrypt,
+            description: desc.into(),
+            maybe_withheld: None
+        }
+    }
+}
+
+
+impl From<MegolmError> for MegolmDecryptionError {
+
+    fn from(value: MegolmError) -> Self {
+        match &value {
+            MegolmError::MissingRoomKey(withheld_code) => {
+                MegolmDecryptionError {
+                    code: DecryptionErrorCode::MissingRoomKey,
+                    description: value.to_string().into(),
+                    maybe_withheld: withheld_code.as_ref().map(|code| code.to_string().to_owned().into()),
+                }
+            }
+            MegolmError::Decryption(vodozemac::megolm::DecryptionError::UnknownMessageIndex(_,_)) => {
+                MegolmDecryptionError {
+                    code: DecryptionErrorCode::UnknownMessageIndex,
+                    description: value.to_string().into(),
+                    maybe_withheld: None
+                }
+            }
+            MegolmError::MismatchedIdentityKeys { key_ed25519: _, device_ed25519: _, key_curve25519: _, device_curve25519: _ } => {
+                MegolmDecryptionError { 
+                    code: DecryptionErrorCode::UnknownMessageIndex,
+                    description: value.to_string().into(),
+                    maybe_withheld: None
+                }
+            }
+            _ => {
+                MegolmDecryptionError { 
+                    code: DecryptionErrorCode::UnableToDecrypt,
+                    description: value.to_string().into(),
+                    maybe_withheld: None
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod attachment;
 pub mod backup;
 pub mod device;
 pub mod encryption;
+pub mod error;
 pub mod events;
 mod future;
 pub mod identifiers;

--- a/tests/machine.test.js
+++ b/tests/machine.test.js
@@ -26,6 +26,8 @@ const {
     getVersions,
     SignatureState,
     BackupDecryptionKey,
+    MegolmDecryptionError,
+    DecryptionErrorCode,
 } = require("../pkg/matrix_sdk_crypto_wasm");
 const { addMachineToMachine } = require("./helper");
 require("fake-indexeddb/auto");
@@ -549,7 +551,13 @@ describe(OlmMachine.name, () => {
                 ciphertext: "blah",
             },
         };
-        await expect(() => m.decryptRoomEvent(JSON.stringify(evt), room)).rejects.toThrowError();
+        try {
+            await m.decryptRoomEvent(JSON.stringify(evt), room);
+            fail('it should not reach here');
+        } catch (err) {
+            expect(err).toBeInstanceOf(MegolmDecryptionError);
+            expect(err.code).toStrictEqual(DecryptionErrorCode.UnableToDecrypt);
+        }
     });
 
     test("can read cross-signing status", async () => {

--- a/tests/machine.test.js
+++ b/tests/machine.test.js
@@ -553,7 +553,7 @@ describe(OlmMachine.name, () => {
         };
         try {
             await m.decryptRoomEvent(JSON.stringify(evt), room);
-            fail('it should not reach here');
+            fail("it should not reach here");
         } catch (err) {
             expect(err).toBeInstanceOf(MegolmDecryptionError);
             expect(err.code).toStrictEqual(DecryptionErrorCode.UnableToDecrypt);


### PR DESCRIPTION
Fixes https://github.com/vector-im/crypto-internal/issues/145

Updated the `decrypt_room_event` API in order to add typed errors.
This level of details is needed by js-sdk/react-sdk, for requesting backup on UTDs as well as to report the type of errors to posthog.

Uses the new feature added here https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/22