### PR TITLE
Fix resource leak in `registerUserIdentityUpdatedCallback`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-base"
 version = "0.6.1"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=9174f120b43453b85202339c21ba6a76bdf610c9#9174f120b43453b85202339c21ba6a76bdf610c9"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=783adb424e23eeac8067844bcf5510f9bede70e1#783adb424e23eeac8067844bcf5510f9bede70e1"
 dependencies = [
  "async-trait",
  "bitflags 2.3.3",
@@ -1089,8 +1089,9 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.6.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=9174f120b43453b85202339c21ba6a76bdf610c9#9174f120b43453b85202339c21ba6a76bdf610c9"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=783adb424e23eeac8067844bcf5510f9bede70e1#783adb424e23eeac8067844bcf5510f9bede70e1"
 dependencies = [
+ "async-trait",
  "futures-core",
  "futures-util",
  "gloo-timers",
@@ -1098,6 +1099,7 @@ dependencies = [
  "ruma",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
  "wasm-bindgen-futures",
@@ -1106,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.6.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=9174f120b43453b85202339c21ba6a76bdf610c9#9174f120b43453b85202339c21ba6a76bdf610c9"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=783adb424e23eeac8067844bcf5510f9bede70e1#783adb424e23eeac8067844bcf5510f9bede70e1"
 dependencies = [
  "aes",
  "async-std",
@@ -1167,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=9174f120b43453b85202339c21ba6a76bdf610c9#9174f120b43453b85202339c21ba6a76bdf610c9"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=783adb424e23eeac8067844bcf5510f9bede70e1#783adb424e23eeac8067844bcf5510f9bede70e1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1192,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.4.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=9174f120b43453b85202339c21ba6a76bdf610c9#9174f120b43453b85202339c21ba6a76bdf610c9"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=783adb424e23eeac8067844bcf5510f9bede70e1#783adb424e23eeac8067844bcf5510f9bede70e1"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1204,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=9174f120b43453b85202339c21ba6a76bdf610c9#9174f120b43453b85202339c21ba6a76bdf610c9"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=783adb424e23eeac8067844bcf5510f9bede70e1#783adb424e23eeac8067844bcf5510f9bede70e1"
 dependencies = [
  "blake3",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ console_error_panic_hook = "0.1.7"
 futures-util = "0.3.27"
 http = "0.2.6"
 js-sys = "0.3.49"
-matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "9174f120b43453b85202339c21ba6a76bdf610c9", features = ["js"] }
-matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "9174f120b43453b85202339c21ba6a76bdf610c9" }
-matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "9174f120b43453b85202339c21ba6a76bdf610c9", optional = true }
+matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "783adb424e23eeac8067844bcf5510f9bede70e1", features = ["js"] }
+matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "783adb424e23eeac8067844bcf5510f9bede70e1" }
+matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "783adb424e23eeac8067844bcf5510f9bede70e1", optional = true }
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.5.0"
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
@@ -53,6 +53,6 @@ zeroize = "1.6.0"
 
 [dependencies.matrix-sdk-crypto]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "9174f120b43453b85202339c21ba6a76bdf610c9"
+rev = "783adb424e23eeac8067844bcf5510f9bede70e1"
 default_features = false
 features = ["js", "backups_v1", "automatic-room-key-forwarding"]


### PR DESCRIPTION
Use the new `Store::identities_stream_raw` method introduced in https://github.com/matrix-org/matrix-rust-sdk/pull/2530 to avoid a resource leak.