### PR TITLE
Fix doc of `verification.generate_qr_code` return

### DIFF
--- a/src/verification.rs
+++ b/src/verification.rs
@@ -1174,7 +1174,7 @@ impl VerificationRequest {
     /// Generate a QR code that can be used by another client to start
     /// a QR code based verification.
     ///
-    /// Returns a `Qr`.
+    /// Returns a `Qr` or `undefined`.
     #[cfg(feature = "qrcode")]
     #[wasm_bindgen(js_name = "generateQrCode")]
     pub fn generate_qr_code(&self) -> Promise {


### PR DESCRIPTION
https://github.com/matrix-org/matrix-rust-sdk/blob/main/crates/matrix-sdk-crypto/src/verification/requests.rs#L395

`generate_qr_code` can return both a `QrVerification` or `None`