### PR TITLE
Rewrite Tracing module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# UNRELEASED
+
+-   Improve logging output to include more information, including data that is
+    attached to tracing spans. Remove the `tracing` feature: tracing support is
+    now always included.
+
 # matrix-sdk-crypto-wasm v2.0.0
 
 -   Updated rust sdk version to revision [c2bb76029ae6d99c741727e0f87abcd734377016](https://github.com/matrix-org/matrix-rust-sdk/commit/c2bb76029ae6d99c741727e0f87abcd734377016), including:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,7 +1092,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-base"
 version = "0.6.1"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=c2bb76029ae6d99c741727e0f87abcd734377016#c2bb76029ae6d99c741727e0f87abcd734377016"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7c958498bfdb41652823bd8bce6a4b25d7c13a97#7c958498bfdb41652823bd8bce6a4b25d7c13a97"
 dependencies = [
  "as_variant",
  "async-trait",
@@ -1115,7 +1115,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.6.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=c2bb76029ae6d99c741727e0f87abcd734377016#c2bb76029ae6d99c741727e0f87abcd734377016"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7c958498bfdb41652823bd8bce6a4b25d7c13a97#7c958498bfdb41652823bd8bce6a4b25d7c13a97"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -1129,6 +1129,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
 ]
@@ -1136,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.6.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=c2bb76029ae6d99c741727e0f87abcd734377016#c2bb76029ae6d99c741727e0f87abcd734377016"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7c958498bfdb41652823bd8bce6a4b25d7c13a97#7c958498bfdb41652823bd8bce6a4b25d7c13a97"
 dependencies = [
  "aes",
  "as_variant",
@@ -1196,7 +1197,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=c2bb76029ae6d99c741727e0f87abcd734377016#c2bb76029ae6d99c741727e0f87abcd734377016"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7c958498bfdb41652823bd8bce6a4b25d7c13a97#7c958498bfdb41652823bd8bce6a4b25d7c13a97"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1222,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.4.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=c2bb76029ae6d99c741727e0f87abcd734377016#c2bb76029ae6d99c741727e0f87abcd734377016"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7c958498bfdb41652823bd8bce6a4b25d7c13a97#7c958498bfdb41652823bd8bce6a4b25d7c13a97"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1234,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=c2bb76029ae6d99c741727e0f87abcd734377016#c2bb76029ae6d99c741727e0f87abcd734377016"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7c958498bfdb41652823bd8bce6a4b25d7c13a97#7c958498bfdb41652823bd8bce6a4b25d7c13a97"
 dependencies = [
  "blake3",
  "chacha20poly1305",
@@ -1267,6 +1268,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1306,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -2094,6 +2111,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
+ "nu-ansi-term",
  "sharded-slab",
  "thread_local",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ console_error_panic_hook = "0.1.7"
 futures-util = "0.3.27"
 http = "0.2.6"
 js-sys = "0.3.49"
-matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "c2bb76029ae6d99c741727e0f87abcd734377016", features = ["js"] }
-matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "c2bb76029ae6d99c741727e0f87abcd734377016" }
-matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "c2bb76029ae6d99c741727e0f87abcd734377016", optional = true }
+matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "7c958498bfdb41652823bd8bce6a4b25d7c13a97", features = ["js"] }
+matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "7c958498bfdb41652823bd8bce6a4b25d7c13a97" }
+matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "7c958498bfdb41652823bd8bce6a4b25d7c13a97", optional = true }
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.5.0"
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
@@ -53,6 +53,6 @@ zeroize = "1.6.0"
 
 [dependencies.matrix-sdk-crypto]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "c2bb76029ae6d99c741727e0f87abcd734377016"
+rev = "7c958498bfdb41652823bd8bce6a4b25d7c13a97"
 default_features = false
 features = ["js", "backups_v1", "automatic-room-key-forwarding"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,8 @@ wasm-opt = ['-Oz']
 crate-type = ["cdylib"]
 
 [features]
-default = ["tracing", "qrcode"]
+default = ["qrcode"]
 qrcode = ["matrix-sdk-crypto/qrcode", "dep:matrix-sdk-qrcode"]
-tracing = []
 
 [dependencies]
 anyhow = "1.0.68"
@@ -46,7 +45,7 @@ matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.5.0"
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.3.14", default-features = false, features = ["registry", "std"] }
+tracing-subscriber = { version = "0.3.14", default-features = false, features = ["registry", "std", "ansi"] }
 wasm-bindgen = "=0.2.84"
 wasm-bindgen-futures = "0.4.33"
 zeroize = "1.6.0"


### PR DESCRIPTION
Rather than using a `Layer` which sends content to the JS console, construct an entire `Subscriber`, which allows us better control over what format is used, and includes data attached to spans.