### PR TITLE
Add git sha/description to version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# UNRELEASED
+
+-   Added bindings versions details to `getVersions()`. Two new fields `git_sha` and
+    `git_description` have been included in the returned `Versions` struct.
+
 # matrix-sdk-crypto-wasm v2.1.1
 
 ## Changes in the underlying Rust crate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,6 +559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1199,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
+ "vergen",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "zeroize",
@@ -1285,6 +1295,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1431,6 +1450,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1772,6 +1797,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,6 +2022,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,6 +2267,17 @@ name = "value-bag"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
+
+[[package]]
+name = "vergen"
+version = "8.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e7dc29b3c54a2ea67ef4f953d5ec0c4085035c0ae2d325be1c0d2144bd9f16"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ wasm-bindgen = "=0.2.84"
 wasm-bindgen-futures = "0.4.33"
 zeroize = "1.6.0"
 
+[build-dependencies]
+vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }
+
 [dependencies.matrix-sdk-crypto]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
 rev = "7440ce0a0cfecf6c5e121e019470fde6ff38fefd"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+use std::error::Error;
+
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    EmitBuilder::builder().git_sha(true).git_describe(true, false, None).emit()?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,13 @@ pub struct Versions {
     /// The version of the matrix-sdk-crypto crate.
     #[wasm_bindgen(readonly)]
     pub matrix_sdk_crypto: JsString,
+    /// The Git commit hash of the crate's source tree at build time.
+    #[wasm_bindgen(readonly)]
+    pub git_sha: JsString,
+    /// The build-time output of the `git describe` command of the source tree
+    /// of crate.
+    #[wasm_bindgen(readonly)]
+    pub git_description: JsString,
 }
 
 /// Get the versions of the Rust libraries we are using.
@@ -61,6 +68,8 @@ pub fn get_versions() -> Versions {
     Versions {
         vodozemac: matrix_sdk_crypto::vodozemac::VERSION.into(),
         matrix_sdk_crypto: matrix_sdk_crypto::VERSION.into(),
+        git_description: env!("VERGEN_GIT_DESCRIBE").to_owned().into(),
+        git_sha: env!("VERGEN_GIT_SHA").to_owned().into(),
     }
 }
 

--- a/tests/machine.test.js
+++ b/tests/machine.test.js
@@ -40,6 +40,8 @@ describe("Versions", () => {
         expect(versions).toBeInstanceOf(Versions);
         expect(versions.vodozemac).toBeDefined();
         expect(versions.matrix_sdk_crypto).toBeDefined();
+        expect(versions.git_sha).toBeDefined();
+        expect(versions.git_description).toBeDefined();
     });
 });
 


### PR DESCRIPTION
Add more informations to the `getVersions()` API:
- The git sha of the binding crate (e.g `e252b3c`)
- The git description of the binding crate (e.g `v2.1.1`)


Using the same method [used for ffi bindings](https://github.com/matrix-org/matrix-rust-sdk/commit/1510576ce1b8312fd972c4563ead46242887cb18)