### PR TITLE
Update rust-sdk ver and `bootstrapCrossSigning` response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # UNRELEASED
 
+**BREAKING CHANGES**
+
+-   `OlmMachine.bootstrapCrossSigning` no longer returns an array of request
+    objects. Rather, it returns a new class (`CrossSigningBootstrapRequests`)
+    which contains the request objects within it.
+
+    As part of this work, `SigningKeysUploadRequest` (which was one of the
+    types formerly returned by `bootstrapCrossSigning`) has been renamed to
+    `UploadSigningKeysRequest` for consistency with the underlying SDK.
+
+## Other changes
+
+-   Olm decryption operations will no longer log large quantities of data about
+    the data `Store`.
+
 # matrix-sdk-crypto-wasm v2.2.0
 
 -   Added bindings versions details to `getVersions()`. Two new fields `git_sha` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1da3ae8dabd9c00f453a329dfe1fb28da3c0a72e2478cdcd93171740c20499"
+checksum = "4b0c4a4f319e45986f347ee47fef8bf5e81c9abc3f6f58dc2391439f30df65f0"
 dependencies = [
  "async-lock",
  "async-task",
@@ -113,7 +113,7 @@ checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
 dependencies = [
  "async-channel",
  "async-executor",
- "async-io",
+ "async-io 1.13.0",
  "async-lock",
  "blocking",
  "futures-lite",
@@ -133,11 +133,31 @@ dependencies = [
  "futures-lite",
  "log",
  "parking",
- "polling",
- "rustix 0.37.24",
+ "polling 2.8.0",
+ "rustix 0.37.27",
  "slab",
  "socket2",
  "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da8f3146014722c89e7859e1d7bb97873125d7346d10ca642ffab794355828"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling 3.3.0",
+ "rustix 0.38.21",
+ "slab",
+ "tracing",
+ "waker-fn",
+ "windows-sys",
 ]
 
 [[package]]
@@ -155,30 +175,30 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
 dependencies = [
- "async-io",
+ "async-io 1.13.0",
  "async-lock",
  "async-signal",
  "blocking",
  "cfg-if",
- "event-listener 3.0.0",
+ "event-listener 3.0.1",
  "futures-lite",
- "rustix 0.38.18",
+ "rustix 0.38.21",
  "windows-sys",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a5415b7abcdc9cd7d63d6badba5288b2ca017e3fbd4173b8f405449f1a2399"
+checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
 dependencies = [
- "async-io",
+ "async-io 2.1.0",
  "async-lock",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.18",
+ "rustix 0.38.21",
  "signal-hook-registry",
  "slab",
  "windows-sys",
@@ -192,7 +212,7 @@ checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
  "async-channel",
  "async-global-executor",
- "async-io",
+ "async-io 1.13.0",
  "async-lock",
  "async-process",
  "crossbeam-utils",
@@ -213,15 +233,15 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.4.1"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9441c6b2fe128a7c2bf680a44c34d0df31ce09e5b7e401fcca3faa483dbc921"
+checksum = "b4eb2cdb97421e01129ccb49169d8279ed21e829929144f4a22a6e54ac549ca1"
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -257,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
@@ -275,9 +295,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "blake3"
@@ -457,9 +477,9 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -523,19 +543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
  "serde",
@@ -644,9 +651,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e56284f00d94c1bc7fd3c77027b4623c88c1f53d8d2394c6199f2921dea325"
+checksum = "01cec0252c2afff729ee6f00e903d479fba81784c8e2bd77447673471fdfaea1"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -681,9 +688,9 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
+checksum = "a481586acf778f1b1455424c343f71124b048ffa5f4fc3f8f6ae9dc432dcb3c7"
 
 [[package]]
 name = "flagset"
@@ -708,24 +715,24 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-lite"
@@ -744,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -755,21 +762,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -848,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "hermit-abi"
@@ -1051,16 +1058,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
-name = "lock_api"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,12 +1098,11 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-base"
 version = "0.6.1"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7440ce0a0cfecf6c5e121e019470fde6ff38fefd#7440ce0a0cfecf6c5e121e019470fde6ff38fefd"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#61eb9cea8c7eeeba53ce2b11ec7578aa50c20331"
 dependencies = [
  "as_variant",
  "async-trait",
- "bitflags 2.4.0",
- "dashmap",
+ "bitflags 2.4.1",
  "eyeball",
  "futures-util",
  "matrix-sdk-common",
@@ -1124,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.6.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7440ce0a0cfecf6c5e121e019470fde6ff38fefd#7440ce0a0cfecf6c5e121e019470fde6ff38fefd"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#61eb9cea8c7eeeba53ce2b11ec7578aa50c20331"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -1146,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.6.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7440ce0a0cfecf6c5e121e019470fde6ff38fefd#7440ce0a0cfecf6c5e121e019470fde6ff38fefd"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#61eb9cea8c7eeeba53ce2b11ec7578aa50c20331"
 dependencies = [
  "aes",
  "as_variant",
@@ -1208,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7440ce0a0cfecf6c5e121e019470fde6ff38fefd#7440ce0a0cfecf6c5e121e019470fde6ff38fefd"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#61eb9cea8c7eeeba53ce2b11ec7578aa50c20331"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1234,7 +1230,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.4.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7440ce0a0cfecf6c5e121e019470fde6ff38fefd#7440ce0a0cfecf6c5e121e019470fde6ff38fefd"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#61eb9cea8c7eeeba53ce2b11ec7578aa50c20331"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1246,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7440ce0a0cfecf6c5e121e019470fde6ff38fefd#7440ce0a0cfecf6c5e121e019470fde6ff38fefd"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#61eb9cea8c7eeeba53ce2b11ec7578aa50c20331"
 dependencies = [
  "blake3",
  "chacha20poly1305",
@@ -1335,22 +1331,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52c774a4c39359c1d1c52e43f73dd91a75a614652c825408eec30c95a9b2067"
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "paste"
@@ -1437,6 +1420,20 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
+ "windows-sys",
+]
+
+[[package]]
+name = "polling"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53b6af1f60f36f8c2ac2aad5459d75a5a9b4be1e8cdd40264f315d78193e531"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.21",
+ "tracing",
  "windows-sys",
 ]
 
@@ -1582,19 +1579,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b323e7196daa571c8584de958be19e92941c41f845776fe06babfe8fa280a2"
 
 [[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "regex"
-version = "1.10.0"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1604,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1615,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3cbb081b9784b07cceb8824c8583f86db4814d172ab043f3c23f7dc600bf83d"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rmp"
@@ -1643,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c63fe7f06396db1480c40cf44a57ad4359847cf6c6b3cdaa67507a00a79bb9"
+checksum = "cc39664df66d707506b1dd318c30e600f25ebc1e7feadf4804ae45db67922c53"
 dependencies = [
  "assign",
  "js_int",
@@ -1707,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.27.2"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f97a398ff20e4de226a5b5b467027eec26a7988e99f98e932f413baef6e8875"
+checksum = "9135a0b84495fabbe46c477a1fcdef181001a215ec4b1f9215320cf980397636"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -1771,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.24"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4279d76516df406a8bd37e7dff53fd37d1a093f997a3c34a5c21658c126db06d"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -1785,11 +1773,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.18"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a74ee2d7c2581cd139b42447d7d9389b889bdaad3a73f1ebb16f2a3237bb19c"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.10",
@@ -1809,12 +1797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "semver"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,9 +1804,9 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
@@ -1851,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1875,9 +1857,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1886,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -1938,16 +1920,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
-
-[[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
@@ -1993,18 +1969,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2091,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2104,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "8ff9e3abce27ee2c9a37f9ad37238c1bdd4e789c84ba37df76aa4d528f5072cc"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2116,18 +2092,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap",
  "serde",
@@ -2138,11 +2114,10 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2150,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2161,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
@@ -2254,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "getrandom",
  "wasm-bindgen",
@@ -2264,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
+checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
 
 [[package]]
 name = "vergen"
@@ -2498,9 +2473,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.16"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
+checksum = "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ console_error_panic_hook = "0.1.7"
 futures-util = "0.3.27"
 http = "0.2.6"
 js-sys = "0.3.49"
-matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "7440ce0a0cfecf6c5e121e019470fde6ff38fefd", features = ["js"] }
-matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "7440ce0a0cfecf6c5e121e019470fde6ff38fefd" }
-matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "7440ce0a0cfecf6c5e121e019470fde6ff38fefd", optional = true }
+matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", features = ["js"] }
+matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk" }
+matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", optional = true }
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.5.0"
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
@@ -55,6 +55,5 @@ vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }
 
 [dependencies.matrix-sdk-crypto]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "7440ce0a0cfecf6c5e121e019470fde6ff38fefd"
 default_features = false
 features = ["js", "backups_v1", "automatic-room-key-forwarding", "message-ids"]

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -28,7 +28,7 @@ use crate::{
     identifiers, identities,
     js::downcast,
     olm, requests,
-    requests::{outgoing_request_to_js_value, ToDeviceRequest},
+    requests::{outgoing_request_to_js_value, CrossSigningBootstrapRequests, ToDeviceRequest},
     responses::{self, response_from_string},
     store,
     store::RoomKeyInfo,
@@ -532,26 +532,14 @@ impl OlmMachine {
     ///   the same request multiple times, setting this argument to false
     ///   enables you to reuse the same request.
     ///
-    /// Returns an `Array` of `OutgoingRequest`s
+    /// Returns a {@link CrossSigningBootstrapRequests}.
     #[wasm_bindgen(js_name = "bootstrapCrossSigning")]
     pub fn bootstrap_cross_signing(&self, reset: bool) -> Promise {
         let me = self.inner.clone();
 
         future_to_promise(async move {
-            let (upload_signing_keys_request, upload_signatures_request) =
-                me.bootstrap_cross_signing(reset).await?;
-
-            let tuple = Array::new();
-            tuple.set(
-                0,
-                requests::UploadSigningKeysRequest::try_from(&upload_signing_keys_request)?.into(),
-            );
-            tuple.set(
-                1,
-                requests::SignatureUploadRequest::try_from(&upload_signatures_request)?.into(),
-            );
-
-            Ok(tuple)
+            let requests = me.bootstrap_cross_signing(reset).await?;
+            Ok(CrossSigningBootstrapRequests::try_from(requests)?)
         })
     }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -545,7 +545,7 @@ impl OlmMachine {
             let tuple = Array::new();
             tuple.set(
                 0,
-                requests::SigningKeysUploadRequest::try_from(&upload_signing_keys_request)?.into(),
+                requests::UploadSigningKeysRequest::try_from(&upload_signing_keys_request)?.into(),
             );
             tuple.set(
                 1,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -28,7 +28,7 @@ use crate::{
     identifiers, identities,
     js::downcast,
     olm, requests,
-    requests::{OutgoingRequest, ToDeviceRequest},
+    requests::{outgoing_request_to_js_value, ToDeviceRequest},
     responses::{self, response_from_string},
     store,
     store::RoomKeyInfo,
@@ -304,18 +304,18 @@ impl OlmMachine {
 
     /// Get the outgoing requests that need to be sent out.
     ///
-    /// This returns a list of `JsValue` to represent either:
-    ///   * `KeysUploadRequest`,
-    ///   * `KeysQueryRequest`,
-    ///   * `KeysClaimRequest`,
-    ///   * `ToDeviceRequest`,
-    ///   * `SignatureUploadRequest`,
-    ///   * `RoomMessageRequest` or
-    ///   * `KeysBackupRequest`.
+    /// This returns a list of values, each of which can be any of:
+    ///   * {@link KeysUploadRequest},
+    ///   * {@link KeysQueryRequest},
+    ///   * {@link KeysClaimRequest},
+    ///   * {@link ToDeviceRequest},
+    ///   * {@link SignatureUploadRequest},
+    ///   * {@link RoomMessageRequest}, or
+    ///   * {@link KeysBackupRequest}.
     ///
     /// Those requests need to be sent out to the server and the
-    /// responses need to be passed back to the state machine using
-    /// `mark_request_as_sent`.
+    /// responses need to be passed back to the state machine
+    /// using {@link OlmMachine.markRequestAsSent}.
     #[wasm_bindgen(js_name = "outgoingRequests")]
     pub fn outgoing_requests(&self) -> Promise {
         let me = self.inner.clone();
@@ -325,8 +325,7 @@ impl OlmMachine {
                 .outgoing_requests()
                 .await?
                 .into_iter()
-                .map(OutgoingRequest)
-                .map(TryFrom::try_from)
+                .map(outgoing_request_to_js_value)
                 .collect::<Result<Vec<JsValue>, _>>()?
                 .into_iter()
                 .collect::<Array>())

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -456,47 +456,46 @@ impl TryFrom<&OriginalToDeviceRequest> for ToDeviceRequest {
     }
 }
 
-// JavaScript has no complex enums like Rust. To return structs of
-// different types, we have no choice that hiding everything behind a
-// `JsValue`.
-pub(crate) struct OutgoingRequest(pub(crate) matrix_sdk_crypto::OutgoingRequest);
+/// Convert an `OutgoingRequest` into a `JsValue`, ready to return to
+/// JavaScript.
+///
+/// JavaScript has no complex enums like Rust. To return structs of
+/// different types, we have no choice that hiding everything behind a
+/// `JsValue`.
+pub fn outgoing_request_to_js_value(
+    outgoing_request: matrix_sdk_crypto::OutgoingRequest,
+) -> Result<JsValue, serde_json::Error> {
+    let request_id = outgoing_request.request_id().to_string();
 
-impl TryFrom<OutgoingRequest> for JsValue {
-    type Error = serde_json::Error;
+    Ok(match outgoing_request.request() {
+        OutgoingRequests::KeysUpload(request) => {
+            JsValue::from(KeysUploadRequest::try_from((request_id, request))?)
+        }
 
-    fn try_from(outgoing_request: OutgoingRequest) -> Result<Self, Self::Error> {
-        let request_id = outgoing_request.0.request_id().to_string();
+        OutgoingRequests::KeysQuery(request) => {
+            JsValue::from(KeysQueryRequest::try_from((request_id, request))?)
+        }
 
-        Ok(match outgoing_request.0.request() {
-            OutgoingRequests::KeysUpload(request) => {
-                JsValue::from(KeysUploadRequest::try_from((request_id, request))?)
-            }
+        OutgoingRequests::KeysClaim(request) => {
+            JsValue::from(KeysClaimRequest::try_from((request_id, request))?)
+        }
 
-            OutgoingRequests::KeysQuery(request) => {
-                JsValue::from(KeysQueryRequest::try_from((request_id, request))?)
-            }
+        OutgoingRequests::ToDeviceRequest(request) => {
+            JsValue::from(ToDeviceRequest::try_from((request_id, request))?)
+        }
 
-            OutgoingRequests::KeysClaim(request) => {
-                JsValue::from(KeysClaimRequest::try_from((request_id, request))?)
-            }
+        OutgoingRequests::SignatureUpload(request) => {
+            JsValue::from(SignatureUploadRequest::try_from((request_id, request))?)
+        }
 
-            OutgoingRequests::ToDeviceRequest(request) => {
-                JsValue::from(ToDeviceRequest::try_from((request_id, request))?)
-            }
+        OutgoingRequests::RoomMessage(request) => {
+            JsValue::from(RoomMessageRequest::try_from((request_id, request))?)
+        }
 
-            OutgoingRequests::SignatureUpload(request) => {
-                JsValue::from(SignatureUploadRequest::try_from((request_id, request))?)
-            }
-
-            OutgoingRequests::RoomMessage(request) => {
-                JsValue::from(RoomMessageRequest::try_from((request_id, request))?)
-            }
-
-            OutgoingRequests::KeysBackup(request) => {
-                JsValue::from(KeysBackupRequest::try_from((request_id, request))?)
-            }
-        })
-    }
+        OutgoingRequests::KeysBackup(request) => {
+            JsValue::from(KeysBackupRequest::try_from((request_id, request))?)
+        }
+    })
 }
 
 /// Represent the type of a request.

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -29,7 +29,7 @@ use wasm_bindgen::prelude::*;
 /// Publishes end-to-end encryption keys for the device.
 ///
 /// [specification]: https://spec.matrix.org/unstable/client-server-api/#post_matrixclientv3keysupload
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[wasm_bindgen(getter_with_clone)]
 pub struct KeysUploadRequest {
     /// The request ID.

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -532,7 +532,7 @@ pub enum RequestType {
 /// This uploads the public cross signing key triplet.
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Debug)]
-pub struct SigningKeysUploadRequest {
+pub struct UploadSigningKeysRequest {
     /// A JSON-encoded string containing the rest of the payload: `master_key`,
     /// `self_signing_key`, `user_signing_key`.
     ///
@@ -542,19 +542,19 @@ pub struct SigningKeysUploadRequest {
 }
 
 #[wasm_bindgen]
-impl SigningKeysUploadRequest {
-    /// Create a new `SigningKeysUploadRequest`.
+impl UploadSigningKeysRequest {
+    /// Create a new `UploadSigningKeysRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(body: JsString) -> SigningKeysUploadRequest {
+    pub fn new(body: JsString) -> UploadSigningKeysRequest {
         Self { body }
     }
 }
 
-impl TryFrom<&OriginalUploadSigningKeysRequest> for SigningKeysUploadRequest {
+impl TryFrom<&OriginalUploadSigningKeysRequest> for UploadSigningKeysRequest {
     type Error = serde_json::Error;
     fn try_from(request: &OriginalUploadSigningKeysRequest) -> Result<Self, Self::Error> {
         {
-            Ok(SigningKeysUploadRequest {
+            Ok(UploadSigningKeysRequest {
                 body: {
                     let mut map = serde_json::Map::new();
                     map.insert(

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -58,7 +58,8 @@ async function addMachineToMachine(machineToAdd, machine) {
     {
         expect(outgoingRequests[1]).toBeInstanceOf(KeysQueryRequest);
 
-        let [signingKeysUploadRequest, _] = await machineToAdd.bootstrapCrossSigning(true);
+        let bootstrapCrossSigningResult = await machineToAdd.bootstrapCrossSigning(true);
+        let signingKeysUploadRequest = bootstrapCrossSigningResult.uploadSigningKeysRequest;
 
         // Let's forge a `KeysQuery`'s response.
         let keyQueryResponse = {


### PR DESCRIPTION
`bootstrapCrossSigning` now returns its own type, which can contain two or three nested requests. Create a new response type wrapper and return it.

Some other cleanups while we are here:

 * Get rid of `OutgoingRequests` wrapper, which was more confusing than helpful.

 * Rename `SigningKeysUploadRequest` to `UploadSigningKeysRequest` for consistency with matrix-rust-sdk.