### PR TITLE
Expose new methods for importing room keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ## Other changes
 
+-   `OlmMachine.importRoomKeys` is now deprecated in favour of separate
+    methods for importing room keys from backup and export,
+    `OlmMachine.importBackedUpRoomKeys` and
+    `OlmMachine.importExportedRoomKeys`.
+
 -   Devices which have exhausted their one-time-keys will now be correctly
     handled in `/keys/claim` responses (we will register them as "failed" and
     stop attempting to send to them for a while.)

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -823,6 +823,13 @@ impl OlmMachine {
     /// Mostly, a deprecated alias for `importExportedRoomKeys`, though the
     /// return type is different.
     ///
+    /// Returns a String containing a JSON-encoded object, holding three
+    /// properties:
+    ///  * `total_count` (the total number of keys found in the export data).
+    ///  * `imported_count` (the number of keys that were imported).
+    ///  * `keys` (the keys that were imported; a map from room id to a map of
+    ///    the sender key to a list of session ids).
+    ///
     /// @deprecated Use `importExportedRoomKeys` or `importBackedUpRoomKeys`.
     #[wasm_bindgen(js_name = "importRoomKeys")]
     pub fn import_room_keys(

--- a/src/types.rs
+++ b/src/types.rs
@@ -265,7 +265,7 @@ impl RoomKeyImportResult {
             key_map.set(&JsString::from(room_id.to_string()), &room_map);
 
             for (sender_key, sessions) in room_result.iter() {
-                let s: Array = sessions.iter().map(String::as_ref).map(JsString::from).collect();
+                let s: Array = sessions.iter().map(|s| JsString::from(s.as_ref())).collect();
                 room_map.set(&JsString::from(sender_key.as_ref()), &Set::new(&s));
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,9 @@
 //! Extra types, like `Signatures`.
 
-use js_sys::{JsString, Map};
+use std::collections::{BTreeMap, BTreeSet};
+
+use js_sys::{Array, JsString, Map, Set};
+use matrix_sdk_common::ruma::OwnedRoomId;
 use matrix_sdk_crypto::backups::{
     SignatureState as InnerSignatureState, SignatureVerification as InnerSignatureVerification,
 };
@@ -225,5 +228,58 @@ impl SignatureVerification {
     #[wasm_bindgen()]
     pub fn trusted(&self) -> bool {
         self.inner.trusted()
+    }
+}
+
+/// The result of a call to {@link OlmMachine.importExportedRoomKeys} or
+/// {@link OlmMachine.importBackedUpRoomKeys}.
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct RoomKeyImportResult {
+    /// The number of room keys that were imported.
+    #[wasm_bindgen(readonly, js_name = "importedCount")]
+    pub imported_count: usize,
+
+    /// The total number of room keys that were found in the export.
+    #[wasm_bindgen(readonly, js_name = "totalCount")]
+    pub total_count: usize,
+
+    /// The map of keys that were imported.
+    ///
+    /// A map from room id to a map of the sender key to a set of session ids.
+    keys: BTreeMap<OwnedRoomId, BTreeMap<String, BTreeSet<String>>>,
+}
+
+#[wasm_bindgen]
+impl RoomKeyImportResult {
+    /// The keys that were imported.
+    ///
+    /// A Map from room id to a Map of the sender key to a Set of session ids.
+    ///
+    /// Typescript type: `Map<string, Map<string, Set<string>>`.
+    pub fn keys(&self) -> Map {
+        let key_map = Map::new();
+
+        for (room_id, room_result) in self.keys.iter() {
+            let room_map = Map::new();
+            key_map.set(&JsString::from(room_id.to_string()), &room_map);
+
+            for (sender_key, sessions) in room_result.iter() {
+                let s: Array = sessions.iter().map(String::as_ref).map(JsString::from).collect();
+                room_map.set(&JsString::from(sender_key.as_ref()), &Set::new(&s));
+            }
+        }
+
+        key_map
+    }
+}
+
+impl From<matrix_sdk_crypto::RoomKeyImportResult> for RoomKeyImportResult {
+    fn from(value: matrix_sdk_crypto::RoomKeyImportResult) -> Self {
+        RoomKeyImportResult {
+            imported_count: value.imported_count,
+            total_count: value.total_count,
+            keys: value.keys,
+        }
     }
 }

--- a/tests/machine.test.js
+++ b/tests/machine.test.js
@@ -686,7 +686,7 @@ describe(OlmMachine.name, () => {
         expect(userId.toString()).toEqual(user.toString());
     });
 
-    test("can export room keys", async  () => {
+    test("can export room keys", async () => {
         let m = await machine();
         await m.shareRoomKey(room, [new UserId("@bob:example.org")], new EncryptionSettings());
 
@@ -713,7 +713,7 @@ describe(OlmMachine.name, () => {
             },
             forwarding_curve25519_key_chain: [],
         });
-    })
+    });
 
     describe("can process exported room keys", () => {
         let exportedRoomKeys;
@@ -773,11 +773,9 @@ describe(OlmMachine.name, () => {
 
             expect(result.importedCount).toStrictEqual(1);
             expect(result.totalCount).toStrictEqual(1);
-            expect(result.keys()).toMatchObject(new Map([[
-                room.toString(), new Map([[
-                    expect.any(String), new Set([expect.any(String)]),
-                ]]),
-            ]]));
+            expect(result.keys()).toMatchObject(
+                new Map([[room.toString(), new Map([[expect.any(String), new Set([expect.any(String)])]])]]),
+            );
         });
 
         test("importing room keys calls RoomKeyUpdatedCallback", async () => {
@@ -790,10 +788,8 @@ describe(OlmMachine.name, () => {
             let keyInfoList = callback.mock.calls[0][0];
             expect(keyInfoList.length).toEqual(1);
             expect(keyInfoList[0].roomId.toString()).toStrictEqual(room.toString());
-        })
+        });
     });
-
-
 
     describe("can do in-room verification", () => {
         let m;
@@ -1112,7 +1108,11 @@ describe(OlmMachine.name, () => {
                 decryptedKeyMap.set(new RoomId(roomId), decryptedRoomKeyMap);
                 for (const [sessionId, keyBackupData] of Object.entries(roomKeys.sessions)) {
                     const decrypted = JSON.parse(
-                        keyBackupKey.decryptV1(keyBackupData.session_data.ephemeral, keyBackupData.session_data.mac, keyBackupData.session_data.ciphertext),
+                        keyBackupKey.decryptV1(
+                            keyBackupData.session_data.ephemeral,
+                            keyBackupData.session_data.mac,
+                            keyBackupData.session_data.ciphertext,
+                        ),
                     );
                     expect(decrypted.algorithm).toStrictEqual("m.megolm.v1.aes-sha2");
                     decryptedRoomKeyMap.set(sessionId, decrypted);
@@ -1126,11 +1126,9 @@ describe(OlmMachine.name, () => {
             const result = await m2.importBackedUpRoomKeys(decryptedKeyMap, progressListener);
             expect(result.importedCount).toStrictEqual(1);
             expect(result.totalCount).toStrictEqual(1);
-            expect(result.keys()).toMatchObject(new Map([[
-                room.toString(), new Map([[
-                    expect.any(String), new Set([expect.any(String)]),
-                ]]),
-            ]]));
+            expect(result.keys()).toMatchObject(
+                new Map([[room.toString(), new Map([[expect.any(String), new Set([expect.any(String)])]])]]),
+            );
 
             expect(progressListener).toHaveBeenCalledTimes(1);
             expect(progressListener).toHaveBeenCalledWith(0, 1);


### PR DESCRIPTION
Exposes the new import methods added in https://github.com/matrix-org/matrix-rust-sdk/pull/2759. Also adds a new return type which doesn't rely quite so much on JSON-encoded objects.

The old method is deprecated.

~~This PR currently based on #53.~~