### PR TITLE
Include debug symbols in wasm output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# UNRELEASED
+
+-   Include Rust symbol names in the generated wasm output.
+    ([#65](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/65))
+
 # matrix-sdk-crypto-wasm v3.3.0
 
 -   Add new properties `roomKeyRequestsEnabled` and `roomKeyForwardingEnabled`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ wasm-opt = ['-Oz', '-g']
 # Tell cargo to run `rustc` with `-C debuginfo=2` - ie, to include debug symbols.
 # https://doc.rust-lang.org/cargo/reference/profiles.html#debug
 debug = true
+# Tell cargo to run `rustc` with `-Oz` - ie, to optimize for size.
+# https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level
+opt-level = 'z'
 
 [lib]
 crate-type = ["cdylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,15 @@ publish = false
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
+################################################################################
+#
+# Configuration for `wasm-pack`
+#
+# See https://rustwasm.github.io/docs/wasm-pack/cargo-toml-configuration.html
+# for details of what can be set here.
+#
+################################################################################
+
 [package.metadata.wasm-pack.profile.profiling]
 wasm-opt = false
 
@@ -24,7 +33,18 @@ demangle-name-section = true
 dwarf-debug-info = true
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-Oz']
+# Tell wasm-opt to:
+#  * `-Oz`: optimise for size
+#  * `-g`: include the "name" section (which holds the printable names for
+#    symbols) in the output.
+wasm-opt = ['-Oz', '-g']
+
+################################################################################
+
+[profile.release]
+# Tell cargo to run `rustc` with `-C debuginfo=2` - ie, to include debug symbols.
+# https://doc.rust-lang.org/cargo/reference/profiles.html#debug
+debug = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,6 @@ wasm-opt = ['-Oz', '-g']
 ################################################################################
 
 [profile.release]
-# Tell cargo to run `rustc` with `-C debuginfo=2` - ie, to include debug symbols.
-# https://doc.rust-lang.org/cargo/reference/profiles.html#debug
-debug = true
 # Tell cargo to run `rustc` with `-Oz` - ie, to optimize for size.
 # https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level
 opt-level = 'z'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ set -e
 
 cd $(dirname "$0")/..
 
-RUSTFLAGS='-C opt-level=z' WASM_BINDGEN_WEAKREF=1 wasm-pack build --target nodejs --scope matrix-org --out-dir pkg "${WASM_PACK_ARGS[@]}"
+wasm-pack build --target nodejs --scope matrix-org --out-dir pkg --weak-refs "${WASM_PACK_ARGS[@]}"
 
 # Convert the Wasm into a JS file that exports the base64'ed Wasm.
 {


### PR DESCRIPTION
In order to help debugging/profiling, it's useful to include the names of the Rust symbols in the generated wasm.

It does increase the wasm from 4.3M to 5.4M (and hence the js module which includes the base64-ed wasm from ~6M to 7.3M) ... but I guess we have to live with that.

There are a couple of commits here. The second isn't strictly related but is a quick cleanup while I was in the area.

