### PR TITLE
Bump dependency versions, including matrix-rust-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_panic"
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
 dependencies = [
  "powerfmt",
 ]
@@ -620,9 +620,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hkdf"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac",
 ]
@@ -727,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "konst"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a6ee015a18f4a121ba670f947f801b207139f0f810b3cd266e319065129782"
+checksum = "8d712a8c49d4274f8d8a5cf61368cb5f3c143d149882b1a2918129e53395fdb0"
 dependencies = [
  "const_panic",
  "konst_kernel",
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "konst_kernel"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3376133edc39f027d551eb77b077c2865a0ef252b2e7d0dd6b6dc303db95d8b5"
+checksum = "dac6ea8c376b6e208a81cf39b8e82bebf49652454d98a4829e907dac16ef1790"
 dependencies = [
  "typewit",
 ]
@@ -786,9 +786,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "log"
@@ -875,7 +875,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-base"
 version = "0.6.1"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#0573137835a17092d45a17944f6a0de3429ecdfe"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#19526cea6bce133fc48904838956846aeb966dc6"
 dependencies = [
  "as_variant",
  "async-trait",
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.6.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#0573137835a17092d45a17944f6a0de3429ecdfe"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#19526cea6bce133fc48904838956846aeb966dc6"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.6.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#0573137835a17092d45a17944f6a0de3429ecdfe"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#19526cea6bce133fc48904838956846aeb966dc6"
 dependencies = [
  "aes",
  "as_variant",
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#0573137835a17092d45a17944f6a0de3429ecdfe"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#19526cea6bce133fc48904838956846aeb966dc6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -994,7 +994,7 @@ dependencies = [
  "matrix-sdk-store-encryption",
  "ruma",
  "serde",
- "serde-wasm-bindgen 0.6.1",
+ "serde-wasm-bindgen 0.6.3",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1006,7 +1006,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.4.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#0573137835a17092d45a17944f6a0de3429ecdfe"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#19526cea6bce133fc48904838956846aeb966dc6"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1018,7 +1018,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#0573137835a17092d45a17944f6a0de3429ecdfe"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#19526cea6bce133fc48904838956846aeb966dc6"
 dependencies = [
  "blake3",
  "chacha20poly1305",
@@ -1089,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -1191,11 +1191,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
 dependencies = [
- "toml_edit 0.20.7",
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1494,9 +1495,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "semver"
@@ -1526,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ba92964781421b6cef36bf0d7da26d201e96d84e1b10e7ae6ed416e516906d"
+checksum = "b9b713f70513ae1f8d92665bbbbda5c295c2cf1da5542881ae5eefe20c9af132"
 dependencies = [
  "js-sys",
  "serde",
@@ -1557,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "serde_html_form"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde65b75f2603066b78d6fa239b2c07b43e06ead09435f60554d3912962b4a3c"
+checksum = "224e6a14f315852940f3ec103125aa6482f0e224732ed91ed3330ed633077c34"
 dependencies = [
  "form_urlencoded",
  "indexmap",
@@ -1644,9 +1645,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1731,9 +1732,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -1766,41 +1767,30 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.8"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.0",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde",
@@ -1884,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
 name = "unicode-ident"
@@ -2092,9 +2082,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winnow"
-version = "0.5.19"
+version = "0.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
This provides these changes from matrix-rust-sdk (edited for brevity):

- 92212cc32843b4 Clarify the meaning of the sessions field in PendingBackup
- 6ffb0181e46f2d Make sure qrcode feature is additive
- 614bf942c082cf build(deps): bump zerocopy from 0.7.26 to 0.7.31
- 512509ce8be9ec Switch to using chunk_large_query_over in mark_inbound_group_sessions_as_backed_up
- 5310f41cdacf68 integration-testing: Add test for QR verification
- 326935db637fe3 feat(base): Correct implementations for `MemoryStore` media removal.
- 416bc8b0e4de2e feat(base): Implement `Media::uri`.
- edd113a17c9276 feat(common): Implement `RingBuffer::remove`.
- a3aa55ce91e159 Use the limit() method to find the variable limit
- c5b11fc2f89ee0 feat(sdk): Simplify code from `Media::get_media_content`.
- e2ea19ee770520 Add rule kind to error messages
- cc38768bf4fb66 notification settings: Don't error if poll start rules are not found
- c87bd4d4eca29a notification settings: Log errors from requests
- 5700c700f0c0e8 error: Use NotificationSettingsError::RuleNotFound's rule ID in display impl
- fff9882792a828 notification settings: Rely more on Ruma methods
- 45f8ff11c2bc5d notification settings: Derive Copy for enum types
- 7c9d842d05d20d notification settings: Use private method to get poll start rule ID
- c3706d7ca0da91 notification settings: Allow to manage keywords (#2905)
- b314da37b80226 feat(ffi): `Timeline::send_image` and `send_video` takes an optional `thumbnail_url`
- 02ba6c0dbe30b1 feat(ffi): `Client::*media*` are now async
- 9756ed28cfff4c verification: Expose the room ID where the verification is happening
- 5701cea51ea6c7 Configure `Instant` wasm polyfill to use monotonic time
- 4ebb8e29b4c74f Provide CryptoStore::mark_sessions_as_backed_up on stores and use it in BackupMachine::mark_request_as_sent
- 3b7f9f7361c26d Reapply "bindings: Use new uniffi-bindgen build mode"
- 7cffc349842fab ffi: Support banning, unbanning and kicking users.
- c4ef967523cc99 dx: tweak debugging of user/device pairs missing a session
- f0b378179e4b2a matrix auth: Await save_session_callback
- ee344112f30109 verification: Expose the QrVerificationState and the stream for its changes
- c707e1f17eb28f feat(bindings): expose a function to send private read receipts (#2906)
- 5ab69f74004a2a ffi: add emoji indices in the session verification data + use decimals as a fallback
- e652069896377a sdk: Use crates.io release of mas-oidc-client
- 5337c9d9ea6870 refactoring: make it clear that notifications aren't stored in the state store
- 4ab79a40857a19 timeline: add the room version in the event_filter parameters
- a132c0a88590df read receipts: apply a default event filter only for events that get rendered
- 5081802177e6fe room: try restoring from a key backup during backpagination too
- 736188811fb1bf ffi: expose the call member state event type for clients to check if users can join calls
- 1337fdf0b8b449 ffi: Expose `is_invite_for_me_enabled` and `set_invite_for_me_enabled` in notification settings