### PR TITLE
Create new `StoreHandle` class to save repeatedly opening stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# UNRELEASED
+
+-   Add a `StoreHandle` class which can be used to hold a connection to a
+    crypto store, and thus improve performance when doing multiple operations
+    on the store.
+    ([#76](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/76))
+
 # matrix-sdk-crypto-wasm v3.5.0
 
 -   Update matrix-rust-sdk version, providing several changes including a fix

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,11 +1,107 @@
 //! Store types.
 
+use std::sync::Arc;
+
+use matrix_sdk_crypto::store::{DynCryptoStore, IntoCryptoStore, MemoryStore};
 use wasm_bindgen::prelude::*;
 
 use crate::{
     encryption::EncryptionAlgorithm, identifiers::RoomId, impl_from_to_inner,
     vodozemac::Curve25519PublicKey,
 };
+
+/// A struct containing an open connection to a CryptoStore.
+///
+/// Opening the CryptoStore can take some time, due to the PBKDF calculation
+/// involved, so if multiple operations are being done on the same store, it is
+/// more efficient to open it once.
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct StoreHandle {
+    pub(crate) store: Arc<DynCryptoStore>,
+}
+
+#[wasm_bindgen]
+impl StoreHandle {
+    /// Open a crypto store.
+    ///
+    /// The created store will be based on IndexedDB if a `store_name` is
+    /// provided; otherwise it will be based on a memory store and once the
+    /// objects is dropped, the keys will be lost.
+    ///
+    /// # Arguments
+    ///
+    ///
+    /// * `store_name` - The name that should be used to open the IndexedDB
+    ///   based database. If this isn't provided, a memory-only store will be
+    ///   used. *Note* the memory-only store will lose your E2EE keys when the
+    ///   `StoreHandle` gets dropped.
+    ///
+    /// * `store_passphrase` - The passphrase that should be used to encrypt the
+    ///   store, for IndexedDB-based stores
+    #[wasm_bindgen(js_name = "open")]
+    pub async fn open_for_js(
+        store_name: Option<String>,
+        store_passphrase: Option<String>,
+    ) -> Result<JsValue, JsValue> {
+        Ok(StoreHandle::open(store_name, store_passphrase)
+            .await
+            .map_err(|e| JsError::from(&*e))?
+            .into())
+    }
+
+    pub(crate) async fn open(
+        store_name: Option<String>,
+        store_passphrase: Option<String>,
+    ) -> Result<StoreHandle, anyhow::Error> {
+        let store = match store_name {
+            Some(store_name) => Self::open_indexeddb(&store_name, store_passphrase).await?,
+
+            None => {
+                if store_passphrase.is_some() {
+                    return Err(anyhow::Error::msg(
+                        "The `store_passphrase` has been set, but it has an effect only if \
+                        `store_name` is set, which is not; please provide one",
+                    ));
+                }
+
+                MemoryStore::new().into_crypto_store()
+            }
+        };
+
+        Ok(Self { store })
+    }
+
+    async fn open_indexeddb(
+        store_name: &String,
+        store_passphrase: Option<String>,
+    ) -> Result<Arc<DynCryptoStore>, matrix_sdk_indexeddb::IndexeddbCryptoStoreError> {
+        let store = match store_passphrase {
+            Some(mut store_passphrase) => {
+                use zeroize::Zeroize;
+
+                let store = matrix_sdk_indexeddb::IndexeddbCryptoStore::open_with_passphrase(
+                    &store_name,
+                    &store_passphrase,
+                )
+                .await?;
+
+                store_passphrase.zeroize();
+                store
+            }
+
+            None => matrix_sdk_indexeddb::IndexeddbCryptoStore::open_with_name(&store_name).await?,
+        };
+
+        Ok(store.into_crypto_store())
+    }
+}
+
+impl IntoCryptoStore for StoreHandle {
+    fn into_crypto_store(self) -> Arc<DynCryptoStore> {
+        self.store.clone()
+    }
+}
 
 /// A struct containing private cross signing keys that can be backed
 /// up or uploaded to the secret store.

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -1,34 +1,35 @@
 import {
+    BackupDecryptionKey,
     CrossSigningStatus,
     DecryptedRoomEvent,
+    DecryptionErrorCode,
     DeviceId,
     DeviceKeyId,
     DeviceLists,
     EncryptionSettings,
     EventId,
+    getVersions,
     InboundGroupSession,
+    KeysBackupRequest,
+    KeysClaimRequest,
     KeysQueryRequest,
     KeysUploadRequest,
     MaybeSignature,
+    MegolmDecryptionError,
     OlmMachine,
     OwnUserIdentity,
     RequestType,
     RoomId,
     RoomMessageRequest,
     ShieldColor,
+    SignatureState,
     SignatureUploadRequest,
+    StoreHandle,
     ToDeviceRequest,
     UserId,
     UserIdentity,
     VerificationRequest,
     Versions,
-    getVersions,
-    SignatureState,
-    BackupDecryptionKey,
-    MegolmDecryptionError,
-    DecryptionErrorCode,
-    KeysClaimRequest,
-    KeysBackupRequest,
 } from "../pkg/matrix_sdk_crypto_wasm";
 import "fake-indexeddb/auto";
 
@@ -53,13 +54,26 @@ describe("Versions", () => {
     });
 });
 
+jest.setTimeout(15000);
+
 describe(OlmMachine.name, () => {
     test("can be instantiated with the async initializer", async () => {
         expect(await OlmMachine.initialize(new UserId("@foo:bar.org"), new DeviceId("baz"))).toBeInstanceOf(OlmMachine);
     });
 
-    test("can be instantiated with a store", async () => {
+    test("can be instantiated with a StoreHandle", async () => {
         let storeName = "hello";
+        let storePassphrase = "world";
+
+        let storeHandle = await StoreHandle.open(storeName, storePassphrase);
+        expect(
+            await OlmMachine.init_from_store(new UserId("@foo:bar.org"), new DeviceId("baz"), storeHandle),
+        ).toBeInstanceOf(OlmMachine);
+        storeHandle.free();
+    });
+
+    test("can be instantiated with store credentials", async () => {
+        let storeName = "hello2";
         let storePassphrase = "world";
 
         const byStoreName = (db: IDBDatabaseInfo) => db.name!.startsWith(storeName);


### PR DESCRIPTION
A prerequisite for supporting migration from libolm: opening the indexeddb takes a long time, so we don't want to do it for each step in the migration.