### PR TITLE
don't die when we have invalid keys in backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # UNRELEASED
 
 -   Report failures to callback when importing backed-up room keys. The
-    callback is now called with a third argument, giving the number of invalid
+    `progress_listener` callback in the `OlmMachine.importBackedUpRoomKeys`
+    function is now called with a third argument, giving the number of invalid
     room keys.
     ([#85](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/85))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # UNRELEASED
 
--   Report failures to callback when importing backed-up room keys.  The
+-   Report failures to callback when importing backed-up room keys. The
     callback is now called with a third argument, giving the number of invalid
     room keys.
     ([#85](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/85))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 -   Report failures to callback when importing backed-up room keys.  The
     callback is now called with a third argument, giving the number of invalid
     room keys.
+    ([#85](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/85))
 
 **BREAKING CHANGES**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # UNRELEASED
 
+-   Report failures to callback when importing backed-up room keys.  The
+    callback is now called with a third argument, giving the number of invalid
+    room keys.
+
 **BREAKING CHANGES**
 
 -   Rename `OlmMachine.init_from_store` introduced in v3.6.0 to `OlmMachine.initFromStore`.

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -998,7 +998,7 @@ impl OlmMachine {
 
         // convert the js-side data into rust data
         let mut keys: BTreeMap<_, BTreeMap<_, _>> = BTreeMap::new();
-        let mut failures: usize = 0;
+        let mut failures = 0;
         for backed_up_room_keys_entry in backed_up_room_keys.entries() {
             let backed_up_room_keys_entry: Array = backed_up_room_keys_entry?.dyn_into()?;
             let room_id =
@@ -1010,15 +1010,13 @@ impl OlmMachine {
             for room_room_keys_entry in room_room_keys.entries() {
                 let room_room_keys_entry: Array = room_room_keys_entry?.dyn_into()?;
                 let session_id: JsString = room_room_keys_entry.get(0).dyn_into()?;
-                serde_wasm_bindgen::from_value::<BackedUpRoomKey>(room_room_keys_entry.get(1))
-                    .map_or_else(
-                        |_| {
-                            failures = failures + 1;
-                        },
-                        |key| {
-                            keys.entry(room_id.clone()).or_default().insert(session_id.into(), key);
-                        },
-                    );
+                if let Ok(key) =
+                    serde_wasm_bindgen::from_value::<BackedUpRoomKey>(room_room_keys_entry.get(1))
+                {
+                    keys.entry(room_id.clone()).or_default().insert(session_id.into(), key);
+                } else {
+                    failures = failures + 1;
+                }
             }
         }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1031,6 +1031,9 @@ impl OlmMachine {
                             .call3(
                                 &JsValue::NULL,
                                 &JsValue::from(progress),
+                                // the "total" that gets passed to this function only counts
+                                // the keys that we passed to `import_backed_up_room_keys`
+                                // so we need to add `failures` to get the actual total
                                 &JsValue::from(total + failures),
                                 &JsValue::from(failures),
                             )

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -998,6 +998,7 @@ impl OlmMachine {
 
         // convert the js-side data into rust data
         let mut keys: BTreeMap<_, BTreeMap<_, _>> = BTreeMap::new();
+        let mut failures: usize = 0;
         for backed_up_room_keys_entry in backed_up_room_keys.entries() {
             let backed_up_room_keys_entry: Array = backed_up_room_keys_entry?.dyn_into()?;
             let room_id =
@@ -1009,10 +1010,15 @@ impl OlmMachine {
             for room_room_keys_entry in room_room_keys.entries() {
                 let room_room_keys_entry: Array = room_room_keys_entry?.dyn_into()?;
                 let session_id: JsString = room_room_keys_entry.get(0).dyn_into()?;
-                let key: BackedUpRoomKey =
-                    serde_wasm_bindgen::from_value(room_room_keys_entry.get(1))?;
-
-                keys.entry(room_id.clone()).or_default().insert(session_id.into(), key);
+                serde_wasm_bindgen::from_value::<BackedUpRoomKey>(room_room_keys_entry.get(1))
+                    .map_or_else(
+                        |_| {
+                            failures = failures + 1;
+                        },
+                        |key| {
+                            keys.entry(room_id.clone()).or_default().insert(session_id.into(), key);
+                        },
+                    );
             }
         }
 
@@ -1022,7 +1028,12 @@ impl OlmMachine {
                 .import_backed_up_room_keys(keys, |progress, total| {
                     if let Some(callback) = &progress_listener {
                         callback
-                            .call2(&JsValue::NULL, &JsValue::from(progress), &JsValue::from(total))
+                            .call3(
+                                &JsValue::NULL,
+                                &JsValue::from(progress),
+                                &JsValue::from(total),
+                                &JsValue::from(failures),
+                            )
                             .expect("Progress listener passed to `importBackedUpRoomKeys` failed");
                     }
                 })

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -982,8 +982,10 @@ impl OlmMachine {
     ///   {@link RoomId}, to a Map from session ID to a (decrypted) session data
     ///   structure.
     ///
-    /// * `progress_listener`: an optional callback that takes 2 arguments:
-    ///   `progress` and `total`, and returns nothing.
+    /// * `progress_listener`: an optional callback that takes 3 arguments:
+    ///   `progress` (the number of keys that have successfully been imported),
+    ///   `total` (the total number of keys), and `failures` (the number of keys
+    ///   that failed to import), and returns nothing.
     ///
     /// # Returns
     ///
@@ -1029,7 +1031,7 @@ impl OlmMachine {
                             .call3(
                                 &JsValue::NULL,
                                 &JsValue::from(progress),
-                                &JsValue::from(total),
+                                &JsValue::from(total + failures),
                                 &JsValue::from(failures),
                             )
                             .expect("Progress listener passed to `importBackedUpRoomKeys` failed");

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1025,16 +1025,16 @@ impl OlmMachine {
         Ok(future_to_promise(async move {
             let result: RoomKeyImportResult = me
                 .backup_machine()
-                .import_backed_up_room_keys(keys, |progress, total| {
+                .import_backed_up_room_keys(keys, |progress, total_valid| {
                     if let Some(callback) = &progress_listener {
                         callback
                             .call3(
                                 &JsValue::NULL,
                                 &JsValue::from(progress),
-                                // the "total" that gets passed to this function only counts
-                                // the keys that we passed to `import_backed_up_room_keys`
-                                // so we need to add `failures` to get the actual total
-                                &JsValue::from(total + failures),
+                                // "total_valid" counts the total number of keys that
+                                // we passed to `import_backed_up_room_keys` so we
+                                // need to add `failures` to get the full total
+                                &JsValue::from(total_valid + failures),
                                 &JsValue::from(failures),
                             )
                             .expect("Progress listener passed to `importBackedUpRoomKeys` failed");

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -1193,6 +1193,8 @@ describe(OlmMachine.name, () => {
                     expect(decrypted.algorithm).toStrictEqual("m.megolm.v1.aes-sha2");
                     decryptedRoomKeyMap.set(sessionId, decrypted);
                 }
+                // and add a bad key
+                decryptedRoomKeyMap.set("invalid", {});
             }
 
             // now import the backup into a new OlmMachine
@@ -1207,7 +1209,7 @@ describe(OlmMachine.name, () => {
             );
 
             expect(progressListener).toHaveBeenCalledTimes(1);
-            expect(progressListener).toHaveBeenCalledWith(0, 1);
+            expect(progressListener).toHaveBeenCalledWith(0, 1, 1);
         });
     });
 

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -1209,7 +1209,7 @@ describe(OlmMachine.name, () => {
             );
 
             expect(progressListener).toHaveBeenCalledTimes(1);
-            expect(progressListener).toHaveBeenCalledWith(0, 1, 1);
+            expect(progressListener).toHaveBeenCalledWith(0, 2, 1);
         });
     });
 


### PR DESCRIPTION
Counts the invalid keys from backup and reports them to the callback, rather than returning an error immediately and stopping import.  Works with JS-SDK PR https://github.com/matrix-org/matrix-js-sdk/pull/4006

Fixes https://github.com/element-hq/element-web/issues/26774