### PR TITLE
Update documentation added in #82

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -23,8 +23,6 @@ impl_from_to_inner!(matrix_sdk_crypto::Device => Device);
 impl Device {
     /// Request an interactive verification with this device.
     ///
-    /// Items inside `methods` will be invalidated by this method.
-    ///
     /// Returns a Promise for a 2-element array `[VerificationRequest,
     /// ToDeviceRequest]`.
     #[wasm_bindgen(js_name = "requestVerification")]

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -56,8 +56,6 @@ impl OwnUserIdentity {
     }
 
     /// Send a verification request to our other devices.
-    ///
-    /// Items inside `methods` will be invalidated by this method.
     #[wasm_bindgen(js_name = "requestVerification")]
     pub fn request_verification(
         &self,
@@ -160,8 +158,6 @@ impl UserIdentity {
 
     /// Create a `VerificationRequest` object after the verification
     /// request content has been sent out.
-    ///
-    /// Items inside `methods` will be invalidated by this method.
     #[wasm_bindgen(js_name = "requestVerification")]
     pub fn request_verification(
         &self,
@@ -189,8 +185,6 @@ impl UserIdentity {
     ///
     /// After the content has been sent out a VerificationRequest can be started
     /// with the `request_verification` method.
-    ///
-    /// Items inside `methods` will be invalidated by this method.
     #[wasm_bindgen(js_name = "verificationRequestContent")]
     pub fn verification_request_content(
         &self,

--- a/src/libolm_migration.rs
+++ b/src/libolm_migration.rs
@@ -223,7 +223,7 @@ impl Migration {
     /// # Arguments
     ///
     /// * `sessions` - An `Array` of {@link PickledSession}s to import. Items
-    ///   inside `sessions` are going to be invalidated by this method.
+    ///   inside `sessions` will be invalidated by this method.
     /// * `pickle_key` - The libolm pickle key that was used to pickle the olm
     ///   session objects.
     /// * `store_handle` - A connection to the CryptoStore which will be used to
@@ -381,8 +381,7 @@ impl Migration {
     /// # Arguments
     ///
     /// * `sessions` - An `Array` of {@link PickledInboundGroupSession}s to
-    ///   import. Items inside `sessions` are going to be invalidated by this
-    ///   method.
+    ///   import. Items inside `sessions` will be invalidated by this method.
     /// * `pickle_key` - The libolm pickle key that was used to pickle the
     ///   megolm session objects.
     /// * `store_handle` - A connection to the CryptoStore which will be used to

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1392,11 +1392,7 @@ impl OlmMachine {
     /// Shared helper for `import_exported_room_keys` and `import_room_keys`.
     ///
     /// Wraps the progress listener in a Rust closure and runs
-    /// `Store::import_exported_room_keys`
-    ///
-    /// Items inside `exported_room_keys` will be invalidated by this method. Be
-    /// careful not to use the `ExportedRoomKey`s after this method has been
-    /// called.
+    /// `Store::import_exported_room_keys`.
     async fn import_exported_room_keys_helper(
         inner: &matrix_sdk_crypto::OlmMachine,
         exported_room_keys: Vec<matrix_sdk_crypto::olm::ExportedRoomKey>,

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -849,6 +849,11 @@ impl VerificationRequest {
     ///
     /// Will be present only if the other side requested the
     /// verification or if we’re in the ready state.
+    ///
+    /// # Returns
+    ///
+    /// `undefined` if we do not yet know the supported methods; otherwise, an
+    /// array of `VerificationMethod`s.
     #[wasm_bindgen(getter, js_name = "theirSupportedMethods")]
     pub fn their_supported_methods(&self) -> Result<Option<Vec<VerificationMethod>>, JsError> {
         self.inner
@@ -949,8 +954,6 @@ impl VerificationRequest {
     ///
     /// `methods` represents the methods that we should advertise as
     /// supported by us.
-    ///
-    /// Items inside `methods` will be invalidated by this method.
     ///
     /// It returns either a `ToDeviceRequest`, a `RoomMessageRequest`
     /// or `undefined`.


### PR DESCRIPTION
#82 updated the documentation on some of the exported methods. This PR cleans up a few bits. Principally: `VerificationMethod` is an int, so there is no "owner", and it is not invalidated by passing it into a Rust method.