### PR TITLE
Give final build output a new name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # UNRELEASED
 
+-   Fix a problem when using matrix-sdk-crypto-wasm in a webapp running
+    in the webpack dev server; when rebuilding, the server would throw an
+    error.
+    ([#109](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/109))
+
 # matrix-sdk-crypto-wasm v4.7.0
 
 -   Update dependencies, including matrix-rust-sdk to

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
         "ruma",
         "nio"
     ],
-    "main": "pkg/matrix_sdk_crypto_wasm.js",
-    "types": "pkg/matrix_sdk_crypto_wasm.d.ts",
+    "main": "pkg/index.js",
+    "types": "pkg/index.d.ts",
     "files": [
         "pkg/matrix_sdk_crypto_wasm_bg.wasm.js",
         "pkg/matrix_sdk_crypto_wasm_bg.wasm.d.ts",
-        "pkg/matrix_sdk_crypto_wasm.js",
-        "pkg/matrix_sdk_crypto_wasm.d.ts"
+        "pkg/index.js",
+        "pkg/index.d.ts"
     ],
     "devDependencies": {
         "@babel/core": "^7.23.5",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,12 +28,15 @@ wasm-pack build --target nodejs --scope matrix-org --out-dir pkg --weak-refs "${
 # In the JavaScript:
 #  1. Strip out the lines that load the WASM, and our new epilogue.
 #  2. Remove the imports of `TextDecoder` and `TextEncoder`. We rely on the global defaults.
+#
+# We create a new file, rather than overwriting the old one, otherwise any
+# webpack-dev-server instance which happens to be watching will get upset over
+# the `require("path")`. We call the output "index.js" because we may as well.
 {
   sed -e '/Text..coder.*= require(.util.)/d' \
       -e '/^const path = /,$d' pkg/matrix_sdk_crypto_wasm.js
   cat scripts/epilogue.js
-} > pkg/matrix_sdk_crypto_wasm.js.new
-mv pkg/matrix_sdk_crypto_wasm.js.new pkg/matrix_sdk_crypto_wasm.js
+} > pkg/index.js
 
-# also extend the typescript
-cat scripts/epilogue.d.ts >> pkg/matrix_sdk_crypto_wasm.d.ts
+# also extend the typescript, and give it a name to match the JS.
+cat pkg/matrix_sdk_crypto_wasm.d.ts scripts/epilogue.d.ts > pkg/index.d.ts

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,13 @@ set -e
 
 cd $(dirname "$0")/..
 
-wasm-pack build --target nodejs --scope matrix-org --out-dir pkg --weak-refs "${WASM_PACK_ARGS[@]}"
+# --no-pack disables generation of a `package.json` file. Such a file is
+# useless to us (our package uses the hand-written one in the root directory),
+# and contains incorrect data (our `main` is `index.js`).
+wasm-pack build --no-pack --target nodejs --scope matrix-org --out-dir pkg --weak-refs "${WASM_PACK_ARGS[@]}"
+
+# Make sure that any existing package.json is deleted.
+[ -f pkg/package.json ] && rm pkg/package.json
 
 # Convert the Wasm into a JS file that exports the base64'ed Wasm.
 {

--- a/tests/asyncload.test.js
+++ b/tests/asyncload.test.js
@@ -1,4 +1,4 @@
-const { UserId, initAsync } = require("../pkg/matrix_sdk_crypto_wasm");
+const { UserId, initAsync } = require("../pkg");
 
 test("can instantiate rust objects with async initialiser", async () => {
     initUserId = () => new UserId("@foo:bar.org");

--- a/tests/attachment.test.js
+++ b/tests/attachment.test.js
@@ -1,4 +1,4 @@
-const { Attachment, EncryptedAttachment } = require("../pkg/matrix_sdk_crypto_wasm");
+const { Attachment, EncryptedAttachment } = require("../pkg");
 
 describe(Attachment.name, () => {
     const originalData = "hello";

--- a/tests/backup.test.js
+++ b/tests/backup.test.js
@@ -1,4 +1,4 @@
-const { BackupDecryptionKey } = require("../pkg/matrix_sdk_crypto_wasm");
+const { BackupDecryptionKey } = require("../pkg");
 
 const aMegolmKey = {
     algorithm: "m.megolm.v1.aes-sha2",

--- a/tests/device.test.js
+++ b/tests/device.test.js
@@ -25,7 +25,7 @@ const {
     Qr,
     QrCode,
     QrCodeScan,
-} = require("../pkg/matrix_sdk_crypto_wasm");
+} = require("../pkg");
 const { zip, addMachineToMachine } = require("./helper");
 const { VerificationRequestPhase, QrState } = require("../pkg");
 

--- a/tests/encryption.test.js
+++ b/tests/encryption.test.js
@@ -3,7 +3,7 @@ const {
     EncryptionSettings,
     HistoryVisibility,
     VerificationState,
-} = require("../pkg/matrix_sdk_crypto_wasm");
+} = require("../pkg");
 
 describe("EncryptionAlgorithm", () => {
     test("has the correct variant values", () => {

--- a/tests/encryption.test.js
+++ b/tests/encryption.test.js
@@ -1,9 +1,4 @@
-const {
-    EncryptionAlgorithm,
-    EncryptionSettings,
-    HistoryVisibility,
-    VerificationState,
-} = require("../pkg");
+const { EncryptionAlgorithm, EncryptionSettings, HistoryVisibility, VerificationState } = require("../pkg");
 
 describe("EncryptionAlgorithm", () => {
     test("has the correct variant values", () => {

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -1,4 +1,4 @@
-const { HistoryVisibility } = require("../pkg/matrix_sdk_crypto_wasm");
+const { HistoryVisibility } = require("../pkg");
 
 describe("HistoryVisibility", () => {
     test("has the correct variant values", () => {

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -1,4 +1,4 @@
-const { DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest } = require("../pkg/matrix_sdk_crypto_wasm");
+const { DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest } = require("../pkg");
 
 function* zip(...arrays) {
     const len = Math.min(...arrays.map((array) => array.length));

--- a/tests/identifiers.test.js
+++ b/tests/identifiers.test.js
@@ -7,7 +7,7 @@ const {
     RoomId,
     ServerName,
     UserId,
-} = require("../pkg/matrix_sdk_crypto_wasm");
+} = require("../pkg");
 
 describe(UserId.name, () => {
     test("cannot be invalid", () => {

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -32,7 +32,7 @@ import {
     UserIdentity,
     VerificationRequest,
     Versions,
-} from "../pkg/matrix_sdk_crypto_wasm";
+} from "../pkg";
 import "fake-indexeddb/auto";
 
 type AnyOutgoingRequest =

--- a/tests/requests.test.js
+++ b/tests/requests.test.js
@@ -7,7 +7,7 @@ const {
     SignatureUploadRequest,
     RoomMessageRequest,
     KeysBackupRequest,
-} = require("../pkg/matrix_sdk_crypto_wasm");
+} = require("../pkg");
 
 describe("RequestType", () => {
     test("has the correct variant values", () => {

--- a/tests/sync_events.test.js
+++ b/tests/sync_events.test.js
@@ -1,4 +1,4 @@
-const { DeviceLists, UserId } = require("../pkg/matrix_sdk_crypto_wasm");
+const { DeviceLists, UserId } = require("../pkg");
 
 describe(DeviceLists.name, () => {
     test("can be empty", () => {

--- a/tests/tracing.test.js
+++ b/tests/tracing.test.js
@@ -1,4 +1,4 @@
-const { Tracing, LoggerLevel, OlmMachine, UserId, DeviceId } = require("../pkg/matrix_sdk_crypto_wasm");
+const { Tracing, LoggerLevel, OlmMachine, UserId, DeviceId } = require("../pkg");
 
 describe("LoggerLevel", () => {
     test("has the correct variant values", () => {


### PR DESCRIPTION
This solves a problem with the webpack-dev-server, which would see the half-built javascript output and explode with a big error about not supporting `require("path")`.