### PR TITLE
Fix backed-up keys being re-backed-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@
 
 -   Update matrix-rust-sdk to `7e44fbca7`, which includes:
 
-    - Avoid emitting entries from `identities_stream_raw` and `devices_stream` when
-      we receive a `/keys/query` response which shows that no devices changed.
-      ([#3442](https://github.com/matrix-org/matrix-rust-sdk/pull/3442)).
+    -   Avoid emitting entries from `identities_stream_raw` and `devices_stream` when
+        we receive a `/keys/query` response which shows that no devices changed.
+        ([#3442](https://github.com/matrix-org/matrix-rust-sdk/pull/3442)).
 
-    - Fix to a bug introduced in matrix-sdk-crypto-wasm v4.10.0 which caused
-      keys that had been imported from key backup to be backed up again, when
-      using the in-memory datastore.
+    -   Fix to a bug introduced in matrix-sdk-crypto-wasm v4.10.0 which caused
+        keys that had been imported from key backup to be backed up again, when
+        using the in-memory datastore.
 
 # matrix-sdk-crypto-wasm v4.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # UNRELEASED
 
+**BREAKING CHANGES**
+
+-   `OlmMachine.importBackedUpRoomKeys` now takes a `backupVersion` argument.
+
+**Other changes**
+
 -   Update matrix-rust-sdk to `7e44fbca7`, which includes:
 
     - Avoid emitting entries from `identities_stream_raw` and `devices_stream` when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # UNRELEASED
 
+-   Update matrix-rust-sdk to `7e44fbca7`, which includes:
+
+    - Avoid emitting entries from `identities_stream_raw` and `devices_stream` when
+      we receive a `/keys/query` response which shows that no devices changed.
+      ([#3442](https://github.com/matrix-org/matrix-rust-sdk/pull/3442)).
+
+    - Fix to a bug introduced in matrix-sdk-crypto-wasm v4.10.0 which caused
+      keys that had been imported from key backup to be backed up again, when
+      using the in-memory datastore.
+
 # matrix-sdk-crypto-wasm v4.10.0
 
 -   Expose new constructor function `OlmMachine.openWithKey()`.
@@ -19,7 +29,7 @@
 -   Add a constructor for the `Curve25519PublicKey` type. This allows us to
     create a `Curve25519PublicKey` from a Base64 string on the Javascript side.
 
--   Update matrix-rust-sdk to `7a887766c`, which includes:
+-   Update matrix-rust-sdk to `d7a887766c`, which includes:
 
     -   Add data types to parse the QR code data for the QR code login defined in
         [MSC4108](https://github.com/matrix-org/matrix-spec-proposals/pull/4108)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#d7a887766ce6d69a2c0487e48d91d350f171303b"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#7e44fbca799a93e5ef9c74e97b61a75293cfbfec"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -868,7 +868,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#d7a887766ce6d69a2c0487e48d91d350f171303b"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#7e44fbca799a93e5ef9c74e97b61a75293cfbfec"
 dependencies = [
  "aes",
  "as_variant",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#d7a887766ce6d69a2c0487e48d91d350f171303b"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#7e44fbca799a93e5ef9c74e97b61a75293cfbfec"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -963,7 +963,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#d7a887766ce6d69a2c0487e48d91d350f171303b"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#7e44fbca799a93e5ef9c74e97b61a75293cfbfec"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#d7a887766ce6d69a2c0487e48d91d350f171303b"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#7e44fbca799a93e5ef9c74e97b61a75293cfbfec"
 dependencies = [
  "base64",
  "blake3",

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -1442,27 +1442,32 @@ describe(OlmMachine.name, () => {
     test("Updating devices should call devicesUpdatedCallback", async () => {
         const userId = new UserId("@alice:example.org");
         const deviceId = new DeviceId("ABCDEF");
-        const machine = await OlmMachine.initialize(userId, deviceId);
+        const firstMachine = await OlmMachine.initialize(userId, deviceId);
 
         const callback = jest.fn().mockImplementation(() => Promise.resolve(undefined));
-        machine.registerDevicesUpdatedCallback(callback);
+        firstMachine.registerDevicesUpdatedCallback(callback);
 
-        const outgoingRequests = await machine.outgoingRequests();
+        const secondDeviceId = new DeviceId("GHIJKL");
+        const secondMachine = await OlmMachine.initialize(userId, secondDeviceId);
+
+        // Fish the KeysUploadRequest out of secondMachine's outgoingRequests.
         let deviceKeys;
-        // outgoingRequests will have a KeysUploadRequest before the
-        // KeysQueryRequest, so we grab the device upload and put it in the
-        // response to the /keys/query
-        for (const request of outgoingRequests) {
+        for (const request of await secondMachine.outgoingRequests()) {
             if (request instanceof KeysUploadRequest) {
                 deviceKeys = JSON.parse(request.body).device_keys;
-            } else if (request instanceof KeysQueryRequest) {
-                await machine.markRequestAsSent(
+            }
+        }
+
+        // ... and feed it into firstMachine's KeysQueryRequest
+        for (const request of await firstMachine.outgoingRequests()) {
+            if (request instanceof KeysQueryRequest) {
+                await firstMachine.markRequestAsSent(
                     request.id,
                     request.type,
                     JSON.stringify({
                         device_keys: {
                             "@alice:example.org": {
-                                ABCDEF: deviceKeys,
+                                GHIJKL: deviceKeys,
                             },
                         },
                     }),

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -1257,7 +1257,7 @@ describe(OlmMachine.name, () => {
             const progressListener = jest.fn();
             const m2 = await machine();
             await m2.saveBackupDecryptionKey(keyBackupKey, "1");
-            const result = await m2.importBackedUpRoomKeys(decryptedKeyMap, progressListener);
+            const result = await m2.importBackedUpRoomKeys(decryptedKeyMap, progressListener, "1");
             expect(result.importedCount).toStrictEqual(1);
             expect(result.totalCount).toStrictEqual(1);
             expect(result.keys()).toMatchObject(


### PR DESCRIPTION
Bump to a version of the rust SDK that includes https://github.com/matrix-org/matrix-rust-sdk/pull/3448 and https://github.com/matrix-org/matrix-rust-sdk/pull/3456, to fix https://github.com/matrix-org/matrix-rust-sdk/issues/3447.

Also, pass the backup version into `import_backed_up_room_keys` to avoid using the deprecated method on `BackupMachine`.