### PR TITLE
Prepare release of v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
 
+# matrix-sdk-crypto-wasm v5.0.0
+
 **BREAKING CHANGES**
 
 -   `OlmMachine.importBackedUpRoomKeys` now takes a `backupVersion` argument.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-wasm",
-    "version": "4.10.0",
+    "version": "5.0.0",
     "homepage": "https://github.com/matrix-org/matrix-rust-sdk-wasm",
     "description": "WebAssembly bindings of the matrix-sdk-crypto encryption library",
     "license": "Apache-2.0",


### PR DESCRIPTION
I've changed the interface of `OlmMachine.importBackedUpRoomKeys`, so this is a breaking change, hence the major version bump