### PR TITLE
Prepare release of v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
 
+# matrix-sdk-crypto-wasm v6.0.0
+
 **BREAKING CHANGES**
 
 -   Rename the `QrCodeData` related methods so they use camel case.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-wasm",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "homepage": "https://github.com/matrix-org/matrix-rust-sdk-wasm",
     "description": "WebAssembly bindings of the matrix-sdk-crypto encryption library",
     "license": "Apache-2.0",


### PR DESCRIPTION
A bunch of methods were renamed and converted to non-async methods, which requires us to do a major bump.