### PR TITLE
Set creation time of OlmDevices migrated from legacy to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # UNRELEASED
 
+-   Set "creation time" of `OlmAccount`s which were migrated from legacy libolm data to the unix epoch, instead of "now". Fixes https://github.com/element-hq/element-web/issues/27590.
+    ([#128](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/128))
+
 # matrix-sdk-crypto-wasm v6.0.0
 
 **BREAKING CHANGES**

--- a/src/libolm_migration.rs
+++ b/src/libolm_migration.rs
@@ -144,7 +144,16 @@ async fn migrate_base_data_to_store(
             dehydrated: false,
             // Assume we have 50 keys on the server, until we get a sync that says fewer.
             uploaded_signed_key_count: 50,
-            creation_local_time: MilliSecondsSinceUnixEpoch::now(),
+
+            // The legacy crypto stack didn't keep a record of when the device was created, so we
+            // have to make something up.
+            //
+            // The main thing the creation time is used for is determining whether an event was sent
+            // before the device was created (and hence should not expect to receive the keys).
+            // To avoid incorrectly marking UTD events sent before migration as "expected UTDs", we
+            // set the "creation time" to zero.
+            creation_local_time: MilliSecondsSinceUnixEpoch(UInt::MIN),
+
             fallback_key_creation_timestamp: None,
         })?;
 

--- a/tests/libolm_migration.test.ts
+++ b/tests/libolm_migration.test.ts
@@ -69,6 +69,7 @@ describe("Migration", () => {
         );
         expect(olmMachine.identityKeys.curve25519.toBase64()).toEqual("LKv0bKbc0EC4h0jknbemv3QalEkeYvuNeUXVRgVVTTU");
         expect(olmMachine.identityKeys.ed25519.toBase64()).toEqual("qK70DEqIXq7T+UU3v/al47Ab4JkMEBLpNrTBMbS5rrw");
+        expect(olmMachine.deviceCreationTimeMs).toEqual(0);
 
         const backupKeys: BackupKeys = await olmMachine.getBackupKeys();
         expect(backupKeys.backupVersion).toEqual("3");


### PR DESCRIPTION
Fixes: https://github.com/element-hq/element-web/issues/27590