### PR TITLE
Fix a doc comment incorrectly stating that the function returns a promise

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -23,8 +23,7 @@ impl_from_to_inner!(matrix_sdk_crypto::Device => Device);
 impl Device {
     /// Request an interactive verification with this device.
     ///
-    /// Returns a Promise for a 2-element array `[VerificationRequest,
-    /// ToDeviceRequest]`.
+    /// Returns a 2-element array `[VerificationRequest, ToDeviceRequest]`.
     #[wasm_bindgen(js_name = "requestVerification")]
     pub fn request_verification(
         &self,


### PR DESCRIPTION
In cbd7ca9d4 the Device.verificationRequest method was converted from an async method to a sync one, this was done because the underlying SDK method has received the same treatment.

The doc comment was not updated to reflect this change and claimed that it's still returning a promise. This patch fixes this mistake.

Closes: https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/issues/127