### PR TITLE
Update to latest Rust SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # UNRELEASED
 
+**BREAKING CHANGES**
+
+-   The format for `EncryptionSettings.sharingStrategy` has changed. It must
+    now be created using the `CollectStrategy.deviceBasedStrategy(...)` or
+    `CollectStrategy.identityBasedStrategy()` functions.
+    ([#141](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/141))
+-   The `OlmMachine.decryptRoomEvent` has a new `DecryptionSettings` parameter
+    that allows specifying the required sender trust level. If the trust level
+    is not met, the decryption will fail. To replicate the old behaviour, use a
+    sender trust level of `TrustRequirement.Untrusted`.
+    ([#141](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/141))
+
 **Security Fixes**
 
 -   Fix `UserIdentity.isVerified` to take into account our own identity
@@ -7,9 +19,34 @@
 
 **Other changes**
 
+-   Add `(Own)UserIdentity.wasPreviouslyVerified()`,
+    `(Own)UserIdentity.withdrawVerification()`, and
+    `(Own)UserIdentity.hasVerificationViolation()` to check and manage the state
+    of users who were previously verified but are no longer verified.
+    ([#141](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/141))
+-   Add `UserIdentity.pinCurrentMasterKey()` and
+    `UserInfo.identityNeedsUserApproval()` to manage user identity changes.
+    ([#141](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/141))
+-   `ShieldState` has a new `code` property that is set when the shield state is
+    not `None`.
+    ([#141](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/141))
 -   Add a new API `Device.encryptToDeviceEvent` to encrypt a to-device message using
     Olm.
     ([#101](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/101))
+
+-   Update matrix-rust-sdk to `07aa6d7bc`, which includes:
+
+    -   **NOTE**: this version causes changes to the format of the serialised
+        data in the CryptoStore, meaning that, once upgraded, it will not be
+        possible to roll back applications to earlier versions without breaking
+        user sessions.
+
+    -   Miscellaneous improvements to logging for verification and
+        `OwnUserIdentity` updates.
+        ([#3949](https://github.com/matrix-org/matrix-rust-sdk/pull/3949))
+
+    -   Add message IDs to all outgoing encrypted to-device messages.
+        ([#3776](https://github.com/matrix-org/matrix-rust-sdk/pull/3776))
 
 # matrix-sdk-crypto-wasm v7.0.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "indexed_db_futures"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0704b71f13f81b5933d791abf2de26b33c40935143985220299a357721166706"
+checksum = "43315957678a70eb21fb0d2384fe86dde0d6c859a01e24ce127eb65a0143d28c"
 dependencies = [
  "accessory",
  "cfg-if",
@@ -672,18 +672,6 @@ checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "block-padding",
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -854,13 +842,12 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#40e3a96ae348f7db1863805e43071596c1052643"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#07aa6d7bc7f8d40809226c01e68f3539c85372c9"
 dependencies = [
  "async-trait",
  "futures-core",
  "futures-util",
  "gloo-timers",
- "instant",
  "ruma",
  "serde",
  "serde_json",
@@ -876,7 +863,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.7.2"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#40e3a96ae348f7db1863805e43071596c1052643"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#07aa6d7bc7f8d40809226c01e68f3539c85372c9"
 dependencies = [
  "aes",
  "as_variant",
@@ -943,7 +930,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#40e3a96ae348f7db1863805e43071596c1052643"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#07aa6d7bc7f8d40809226c01e68f3539c85372c9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -971,7 +958,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.7.1"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#40e3a96ae348f7db1863805e43071596c1052643"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#07aa6d7bc7f8d40809226c01e68f3539c85372c9"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -983,7 +970,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#40e3a96ae348f7db1863805e43071596c1052643"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#07aa6d7bc7f8d40809226c01e68f3539c85372c9"
 dependencies = [
  "base64",
  "blake3",
@@ -1325,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
+source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
 dependencies = [
  "assign",
  "js_int",
@@ -1339,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
+source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
 dependencies = [
  "as_variant",
  "assign",
@@ -1362,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
+source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
 dependencies = [
  "as_variant",
  "base64",
@@ -1394,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
+source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -1417,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
+source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
 dependencies = [
  "js_int",
  "thiserror",
@@ -1426,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
+source = "git+https://github.com/matrix-org/ruma?rev=17f6e555528512319e706bb2cfe68a12ec5603b6#17f6e555528512319e706bb2cfe68a12ec5603b6"
 dependencies = [
  "once_cell",
  "proc-macro-crate",

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -127,7 +127,7 @@ pub struct CollectStrategy {
 
 #[wasm_bindgen]
 impl CollectStrategy {
-    /// Tests for equality between two [`CollecStrategy`]s.
+    /// Tests for equality between two [`CollectStrategy`]s.
     #[wasm_bindgen]
     pub fn eq(&self, other: &CollectStrategy) -> bool {
         self == other

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use matrix_sdk_common::deserialized_responses::ShieldState as RustShieldState;
+pub use matrix_sdk_common::deserialized_responses::ShieldStateCode;
 use wasm_bindgen::prelude::*;
 
 use crate::events;
@@ -187,6 +188,9 @@ pub enum ShieldColor {
 pub struct ShieldState {
     /// The shield color
     pub color: ShieldColor,
+    /// A machine-readable representation of the authenticity for a
+    /// `ShieldState`.
+    pub code: Option<ShieldStateCode>,
     message: Option<String>,
 }
 
@@ -202,13 +206,17 @@ impl ShieldState {
 impl From<RustShieldState> for ShieldState {
     fn from(value: RustShieldState) -> Self {
         match value {
-            RustShieldState::Red { message } => {
-                Self { color: ShieldColor::Red, message: Some(message.to_owned()) }
-            }
-            RustShieldState::Grey { message } => {
-                Self { color: ShieldColor::Grey, message: Some(message.to_owned()) }
-            }
-            RustShieldState::None => Self { color: ShieldColor::None, message: None },
+            RustShieldState::Red { message, code } => Self {
+                color: ShieldColor::Red,
+                code: Some(code),
+                message: Some(message.to_owned()),
+            },
+            RustShieldState::Grey { message, code } => Self {
+                color: ShieldColor::Grey,
+                code: Some(code),
+                message: Some(message.to_owned()),
+            },
+            RustShieldState::None => Self { color: ShieldColor::None, code: None, message: None },
         }
     }
 }

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -213,6 +213,31 @@ impl From<TrustRequirement> for matrix_sdk_crypto::TrustRequirement {
     }
 }
 
+/// Settings for decrypting messages
+#[wasm_bindgen(getter_with_clone)]
+#[derive(Debug, Clone)]
+pub struct DecryptionSettings {
+    /// The trust level required to decrypt the event
+    pub sender_device_trust_requirement: TrustRequirement,
+}
+
+#[wasm_bindgen]
+impl DecryptionSettings {
+    /// Create a new `DecryptionSettings` with the given trust requirement.
+    #[wasm_bindgen(constructor)]
+    pub fn new(sender_device_trust_requirement: TrustRequirement) -> DecryptionSettings {
+        Self { sender_device_trust_requirement }
+    }
+}
+
+impl From<&DecryptionSettings> for matrix_sdk_crypto::DecryptionSettings {
+    fn from(value: &DecryptionSettings) -> Self {
+        Self {
+            sender_device_trust_requirement: value.sender_device_trust_requirement.clone().into(),
+        }
+    }
+}
+
 /// Take a look at [`matrix_sdk_common::deserialized_responses::ShieldState`]
 /// for more info.
 #[wasm_bindgen]

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,8 @@ pub enum DecryptionErrorCode {
     /// device we received the room key from and the identity keys recorded in
     /// the plaintext of the room key to-device message.
     MismatchedIdentityKeys,
+    /// The sender does not satisfy the requested trust requirement.
+    SenderIdentityNotTrusted,
     /// Other failure.
     UnableToDecrypt,
 }
@@ -65,6 +67,11 @@ impl From<MegolmError> for MegolmDecryptionError {
             },
             MegolmError::MismatchedIdentityKeys { .. } => MegolmDecryptionError {
                 code: DecryptionErrorCode::UnknownMessageIndex,
+                description: value.to_string().into(),
+                maybe_withheld: None,
+            },
+            MegolmError::SenderIdentityNotTrusted(..) => MegolmDecryptionError {
+                code: DecryptionErrorCode::SenderIdentityNotTrusted,
                 description: value.to_string().into(),
                 maybe_withheld: None,
             },

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -472,9 +472,11 @@ impl OlmMachine {
         &self,
         event: &str,
         room_id: &identifiers::RoomId,
+        decryption_settings: &encryption::DecryptionSettings,
     ) -> Result<Promise, JsError> {
         let event: Raw<_> = serde_json::from_str(event)?;
         let room_id = room_id.inner.clone();
+        let decryption_settings = decryption_settings.into();
         let me = self.inner.clone();
 
         Ok(future_to_promise_with_custom_error::<
@@ -483,7 +485,7 @@ impl OlmMachine {
             MegolmDecryptionError,
         >(async move {
             let room_event = me
-                .decrypt_room_event(&event, room_id.as_ref())
+                .decrypt_room_event(&event, room_id.as_ref(), &decryption_settings)
                 .await
                 .map_err(MegolmDecryptionError::from)?;
             Ok(responses::DecryptedRoomEvent::from(room_event))

--- a/tests/dehydrated_devices.test.ts
+++ b/tests/dehydrated_devices.test.ts
@@ -1,4 +1,5 @@
 import {
+    DecryptionSettings,
     DeviceId,
     DeviceLists,
     EncryptionSettings,
@@ -7,6 +8,7 @@ import {
     OlmMachine,
     RequestType,
     RoomId,
+    TrustRequirement,
     UserId,
 } from "../pkg/matrix_sdk_crypto_wasm";
 import "fake-indexeddb/auto";
@@ -131,7 +133,8 @@ describe("dehydrated devices", () => {
             },
         });
 
-        const decrypted = await machine2.decryptRoomEvent(encryptedEvent, room);
+        const decryptionSettings = new DecryptionSettings(TrustRequirement.Untrusted);
+        const decrypted = await machine2.decryptRoomEvent(encryptedEvent, room, decryptionSettings);
         const decryptedEvent = JSON.parse(decrypted.event);
         expect(decryptedEvent.content.body).toStrictEqual("Hello, World!");
     });

--- a/tests/encryption.test.js
+++ b/tests/encryption.test.js
@@ -37,9 +37,9 @@ describe(EncryptionSettings.name, () => {
     test("checks the sharing strategy values", () => {
         const es = new EncryptionSettings();
 
-        es.sharingStrategy = CollectStrategy.DeviceBasedStrategyAllDevices;
+        es.sharingStrategy = CollectStrategy.deviceBasedStrategy(false, false);
 
-        expect(es.sharingStrategy).toStrictEqual(CollectStrategy.DeviceBasedStrategyAllDevices);
+        expect(es.sharingStrategy.eq(CollectStrategy.deviceBasedStrategy(false, false))).toBe(true);
         expect(() => {
             es.historyVisibility = 42;
         }).toThrow();

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -3,6 +3,7 @@ import {
     CrossSigningStatus,
     DecryptedRoomEvent,
     DecryptionErrorCode,
+    DecryptionSettings,
     DeviceId,
     DeviceKeyId,
     DeviceLists,
@@ -30,6 +31,7 @@ import {
     SignatureUploadRequest,
     StoreHandle,
     ToDeviceRequest,
+    TrustRequirement,
     UserId,
     UserIdentity,
     VerificationRequest,
@@ -619,7 +621,8 @@ describe(OlmMachine.name, () => {
                 },
             });
 
-            const decrypted = await m.decryptRoomEvent(stringifiedEvent, room);
+            const decryptionSettings = new DecryptionSettings(TrustRequirement.Untrusted);
+            const decrypted = await m.decryptRoomEvent(stringifiedEvent, room, decryptionSettings);
             expect(decrypted).toBeInstanceOf(DecryptedRoomEvent);
 
             const event = JSON.parse(decrypted.event);
@@ -661,7 +664,8 @@ describe(OlmMachine.name, () => {
             },
         };
         try {
-            await m.decryptRoomEvent(JSON.stringify(evt), room);
+            const decryptionSettings = new DecryptionSettings(TrustRequirement.Untrusted);
+            await m.decryptRoomEvent(JSON.stringify(evt), room, decryptionSettings);
             fail("it should not reach here");
         } catch (err) {
             expect(err).toBeInstanceOf(MegolmDecryptionError);

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -103,7 +103,7 @@ describe(OlmMachine.name, () => {
         expect(databases).toHaveLength(2);
         expect(databases).toStrictEqual([
             { name: `${storeName}::matrix-sdk-crypto-meta`, version: 1 },
-            { name: `${storeName}::matrix-sdk-crypto`, version: 11 },
+            { name: `${storeName}::matrix-sdk-crypto`, version: 12 },
         ]);
 
         // Creating a new Olm machine, with the stored state.
@@ -222,7 +222,7 @@ describe(OlmMachine.name, () => {
         expect(databases).toHaveLength(2);
         expect(databases).toStrictEqual([
             { name: `${storeName}::matrix-sdk-crypto-meta`, version: 1 },
-            { name: `${storeName}::matrix-sdk-crypto`, version: 11 },
+            { name: `${storeName}::matrix-sdk-crypto`, version: 12 },
         ]);
 
         // Let's force to close the `OlmMachine`.

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -25,6 +25,7 @@ import {
     RoomMessageRequest,
     RoomSettings,
     ShieldColor,
+    ShieldStateCode,
     SignatureState,
     SignatureUploadRequest,
     StoreHandle,
@@ -631,7 +632,9 @@ describe(OlmMachine.name, () => {
             expect(decrypted.senderClaimedEd25519Key).toBeDefined();
             expect(decrypted.forwardingCurve25519KeyChain).toHaveLength(0);
             expect(decrypted.shieldState(true).color).toStrictEqual(ShieldColor.Red);
+            expect(decrypted.shieldState(true).code).toStrictEqual(ShieldStateCode.UnverifiedIdentity);
             expect(decrypted.shieldState(false).color).toStrictEqual(ShieldColor.Red);
+            expect(decrypted.shieldState(false).code).toStrictEqual(ShieldStateCode.UnsignedDevice);
 
             const decryptionInfo = await m.getRoomEventEncryptionInfo(stringifiedEvent, room);
             expect(decryptionInfo.sender.toString()).toStrictEqual(user.toString());
@@ -639,7 +642,9 @@ describe(OlmMachine.name, () => {
             expect(decryptionInfo.senderCurve25519Key).toBeDefined();
             expect(decryptionInfo.senderClaimedEd25519Key).toBeDefined();
             expect(decryptionInfo.shieldState(true).color).toStrictEqual(ShieldColor.Red);
+            expect(decryptionInfo.shieldState(true).code).toStrictEqual(ShieldStateCode.UnverifiedIdentity);
             expect(decryptionInfo.shieldState(false).color).toStrictEqual(ShieldColor.Red);
+            expect(decryptionInfo.shieldState(false).code).toStrictEqual(ShieldStateCode.UnsignedDevice);
         });
     });
 

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -731,6 +731,10 @@ describe(OlmMachine.name, () => {
 
         const identity = await m.getIdentity(user);
 
+        expect(identity.isVerified()).toStrictEqual(true);
+        expect(identity.wasPreviouslyVerified()).toStrictEqual(true);
+        expect(identity.hasVerificationViolation()).toStrictEqual(false);
+
         expect(identity).toBeInstanceOf(OwnUserIdentity);
         const masterKey = JSON.parse(identity.masterKey);
         const selfSigningKey = JSON.parse(identity.selfSigningKey);
@@ -1055,6 +1059,9 @@ describe(OlmMachine.name, () => {
 
             expect(identity).toBeInstanceOf(UserIdentity);
             expect(identity.isVerified()).toStrictEqual(false);
+            expect(identity.wasPreviouslyVerified()).toStrictEqual(false);
+            expect(identity.hasVerificationViolation()).toStrictEqual(false);
+            expect(identity.identityNeedsUserApproval()).toStrictEqual(false);
 
             const eventId = new EventId("$Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg");
             const verificationRequest = await identity.requestVerification(room, eventId);


### PR DESCRIPTION
changes:
- add support for `ShieldStateCode` (ref: matrix-org/matrix-rust-sdk#3786)
- add `error_on_verified_user_problem` field in device-based strategy (ref: matrix-org/matrix-rust-sdk#3810)
  - since the device-based strategy was getting more complicated with new fields, I opted to change the JavaScript interface so that it's more structured, rather than trying to throw new variants into the enum to cover all the options
- add decryption settings for checking sender device trust (ref: matrix-org/matrix-rust-sdk#3899)
- expose the functions for handling identity pinning and previously-verified users (ref: matrix-org/matrix-rust-sdk#3846, matrix-org/matrix-rust-sdk#3795, matrix-org/matrix-rust-sdk#2629)