### PR TITLE
Bring up-to-date with latest matrix-sdk (5d46b35d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # UNRELEASED
 
+**BREAKING CHANGES**
+
+-   Rename `DecryptionErrorCode.SenderIdentityPreviouslyVerified` to
+    `SenderIdentityVerificationViolation` (in line with changes to
+    matrix-rust-sdk).
+
+-   Rename `UserIdentity` to `OtherUserIdentity` (in line with changes
+    to matrix-rust-sdk).
+
+-   Update matrix-rust-sdk to `#5d46b35d`.
+
 # matrix-sdk-crypto-wasm v9.1.0
 
 -   Update matrix-rust-sdk to `866b6e5f`, which includes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.23"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
 dependencies = [
  "shlex",
 ]
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gloo-timers"
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "hkdf"
@@ -639,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#866b6e5f2d84b33eb4592e628fccfcebe04e8f13"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#5d46b35d95a4e4255d6c1f2f8684ca7f0bd7bfa6"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -847,7 +847,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.7.2"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#866b6e5f2d84b33eb4592e628fccfcebe04e8f13"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#5d46b35d95a4e4255d6c1f2f8684ca7f0bd7bfa6"
 dependencies = [
  "aes",
  "as_variant",
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#866b6e5f2d84b33eb4592e628fccfcebe04e8f13"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#5d46b35d95a4e4255d6c1f2f8684ca7f0bd7bfa6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.7.1"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#866b6e5f2d84b33eb4592e628fccfcebe04e8f13"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#5d46b35d95a4e4255d6c1f2f8684ca7f0bd7bfa6"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#866b6e5f2d84b33eb4592e628fccfcebe04e8f13"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#5d46b35d95a4e4255d6c1f2f8684ca7f0bd7bfa6"
 dependencies = [
  "base64",
  "blake3",
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
@@ -1864,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -2099,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "wildmatch"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3928939971918220fed093266b809d1ee4ec6c1a2d72692ff6876898f3b16c19"
+checksum = "68ce1ab1f8c62655ebe1350f589c61e505cf94d385bc6a12899442d9081e71fd"
 
 [[package]]
 name = "winapi"

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,7 @@ pub enum DecryptionErrorCode {
     /// The sender device is not cross-signed.
     UnsignedSenderDevice,
     /// The sender's identity is unverified, but was previously verified.
-    SenderIdentityPreviouslyVerified,
+    SenderIdentityVerificationViolation,
     /// Other failure.
     UnableToDecrypt,
 }
@@ -75,9 +75,9 @@ impl From<MegolmError> for MegolmDecryptionError {
                 description: value.to_string().into(),
                 maybe_withheld: None,
             },
-            MegolmError::SenderIdentityNotTrusted(VerificationLevel::PreviouslyVerified) => {
+            MegolmError::SenderIdentityNotTrusted(VerificationLevel::VerificationViolation) => {
                 MegolmDecryptionError {
-                    code: DecryptionErrorCode::SenderIdentityPreviouslyVerified,
+                    code: DecryptionErrorCode::SenderIdentityVerificationViolation,
                     description: value.to_string().into(),
                     maybe_withheld: None,
                 }

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -9,19 +9,19 @@ use crate::{
     verification::{self, VerificationRequest},
 };
 
-pub(crate) struct UserIdentities {
-    inner: matrix_sdk_crypto::UserIdentities,
+pub(crate) struct UserIdentity {
+    inner: matrix_sdk_crypto::UserIdentity,
 }
 
-impl_from_to_inner!(matrix_sdk_crypto::UserIdentities => UserIdentities);
+impl_from_to_inner!(matrix_sdk_crypto::UserIdentity => UserIdentity);
 
-impl From<UserIdentities> for JsValue {
-    fn from(user_identities: UserIdentities) -> Self {
-        use matrix_sdk_crypto::UserIdentities::*;
+impl From<UserIdentity> for JsValue {
+    fn from(user_identities: UserIdentity) -> Self {
+        use matrix_sdk_crypto::UserIdentity::*;
 
         match user_identities.inner {
             Own(own) => JsValue::from(OwnUserIdentity::from(own)),
-            Other(other) => JsValue::from(UserIdentity::from(other)),
+            Other(other) => JsValue::from(OtherUserIdentity::from(other)),
         }
     }
 }
@@ -164,14 +164,14 @@ impl OwnUserIdentity {
 /// to be requested to verify our own device with the user identity.
 #[wasm_bindgen]
 #[derive(Debug)]
-pub struct UserIdentity {
-    inner: matrix_sdk_crypto::UserIdentity,
+pub struct OtherUserIdentity {
+    inner: matrix_sdk_crypto::OtherUserIdentity,
 }
 
-impl_from_to_inner!(matrix_sdk_crypto::UserIdentity => UserIdentity);
+impl_from_to_inner!(matrix_sdk_crypto::OtherUserIdentity => OtherUserIdentity);
 
 #[wasm_bindgen]
-impl UserIdentity {
+impl OtherUserIdentity {
     /// Is this user identity verified?
     #[wasm_bindgen(js_name = "isVerified")]
     pub fn is_verified(&self) -> bool {

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -33,7 +33,7 @@ import {
     ToDeviceRequest,
     TrustRequirement,
     UserId,
-    UserIdentity,
+    OtherUserIdentity,
     VerificationRequest,
     Versions,
 } from "../pkg";
@@ -1062,7 +1062,7 @@ describe(OlmMachine.name, () => {
             let _ = m.bootstrapCrossSigning(true);
             const identity = await m.getIdentity(new UserId("@example:morpheus.localhost"));
 
-            expect(identity).toBeInstanceOf(UserIdentity);
+            expect(identity).toBeInstanceOf(OtherUserIdentity);
             expect(identity.isVerified()).toStrictEqual(false);
             expect(identity.wasPreviouslyVerified()).toStrictEqual(false);
             expect(identity.hasVerificationViolation()).toStrictEqual(false);


### PR DESCRIPTION
In my quest to make method names consistent I first needed to reflect previous changes from matrix-sdk.