### PR TITLE
Issue template for latest matrix-sdk failure mentions git cliff instead of CHANGELOG

### DIFF
--- a/.github/latest_matrix_sdk_failed_issue_template.md
+++ b/.github/latest_matrix_sdk_failed_issue_template.md
@@ -1,11 +1,14 @@
 ---
 title: Building matrix-rust-sdk-crypto-wasm against the latest matrix-sdk Rust is failing
 ---
-Something changed in
-[matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk)'s crypto crate
-that will break the build of this repo (matrix-rust-sdk-crypto-wasm) when we
-update to it.
+Something changed in [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk)'s crypto crate that will break the build of this repo (matrix-rust-sdk-crypto-wasm) when we update to it.
 
-See the crypto crate's
-[CHANGELOG](https://github.com/matrix-org/matrix-rust-sdk/blob/main/crates/matrix-sdk-crypto/CHANGELOG.md)
-for possible hints about what changed and how to fix it.
+To see the latest changes in matrix-sdk-crypto, use [git cliff](https://git-cliff.org/):
+
+```sh
+git cliff from_commit..to_commit
+```
+
+(You can see which commits to supply by running `cargo update matrix-sdk-common` in this repo and diffing `Cargo.lock`.)
+
+This should give you a hint about what changed.


### PR DESCRIPTION
Fixes https://github.com/element-hq/crypto-internal/issues/391