### PR TITLE
Further shrink the WASM output by using more aggressive optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ wasm-opt = ['-Oz', '-g']
 # Tell cargo to run `rustc` with `-Oz` - ie, to optimize for size.
 # https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level
 opt-level = 'z'
+# Use a single codegen-unit to enable better optimizations
+codegen-units = 1
+# Enable fat link time optimization
+lto = true
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
This is significantly more expensive at compilation time, but shrinks the size of the WASM file from 6MB to 5MB (2.6MB to 1.8MB compressed).
