### PR TITLE
Stop deleting build results during rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 -   The published package is now a proper dual CommonJS/ESM package.
 -   The WebAssembly module is now loaded using `fetch` on Web platforms, reducing
     the bundle size significantly, as well as the time it takes to compile it.
-    ([#167](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/167))
+    ([#167](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/167)),
+    ([#175](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/175))
 
 **BREAKING CHANGES**
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,8 +9,6 @@ cd "$(dirname "$0")"/..
 
 WASM_PACK_ARGS="${WASM_PACK_ARGS:-}"
 
-rm -rf pkg
-
 # Generate the JavaScript bindings
 # --no-pack disables generation of a `package.json` file, as we're managing it ourselves.
 wasm-pack build --no-pack --target bundler --scope matrix-org --out-dir pkg --weak-refs "${WASM_PACK_ARGS}"


### PR DESCRIPTION
This solves a problem, introduced in #167, with the webpack-dev-server, which would see the half-built javascript output and explode with a big error about `Can't resolve './pkg/matrix_sdk_crypto_wasm_bg.js'`

(See also #109, where a similar problem was fixed before.)