### PR TITLE
Silence annoying lint warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,8 @@ vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }
 git = "https://github.com/matrix-org/matrix-rust-sdk"
 default_features = false
 features = ["js", "automatic-room-key-forwarding"]
+
+[lints.rust]
+# Workaround for https://github.com/rustwasm/wasm-bindgen/issues/4283, while we work up the courage to upgrade
+# wasm-bindgen
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/132577 (currently in rust nightly), we get hundreds of lint warnings:

```
warning: unexpected `cfg` condition name: `wasm_bindgen_unstable_test_coverage`
  --> src/rust/lib.rs:83:1
   |
83 | #[wasm_bindgen(start)]
```

The correct solution is to upgrade wasm-bindgen, but legend has it that is difficult. For now, let's silence the lint.