### PR TITLE
Release v12.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # UNRELEASED
 
+# matrix-sdk-crypto-wasm v12.1.0
+
+-   Update matrix-rusk-sdk to `37c17cf854a70f` for the fix for
+    https://github.com/matrix-org/matrix-rust-sdk/issues/4424
+
 # matrix-sdk-crypto-wasm v12.0.0
 
 -   Update matrix-rusk-sdk to `e99939db857ca`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#e99939db857ca36054c0023ef68cc181236fdee4"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?branch=release-for-crypto-wasm-12#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
 dependencies = [
  "async-trait",
  "eyeball-im",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#e99939db857ca36054c0023ef68cc181236fdee4"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?branch=release-for-crypto-wasm-12#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
 dependencies = [
  "aes",
  "aquamarine",
@@ -1135,7 +1135,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#e99939db857ca36054c0023ef68cc181236fdee4"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?branch=release-for-crypto-wasm-12#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#e99939db857ca36054c0023ef68cc181236fdee4"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?branch=release-for-crypto-wasm-12#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1175,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#e99939db857ca36054c0023ef68cc181236fdee4"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?branch=release-for-crypto-wasm-12#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,9 @@ console_error_panic_hook = "0.1.7"
 futures-util = "0.3.27"
 http = "1.1.0"
 js-sys = "0.3.49"
-matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", features = ["js"] }
-matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", default-features = false, features = ["e2e-encryption"] }
-matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", optional = true }
+matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", features = ["js"], branch="release-for-crypto-wasm-12" }
+matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", default-features = false, features = ["e2e-encryption"], branch="release-for-crypto-wasm-12" }
+matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", optional = true, branch="release-for-crypto-wasm-12" }
 serde = "1.0.91"
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.5.0"
@@ -84,6 +84,7 @@ vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }
 git = "https://github.com/matrix-org/matrix-rust-sdk"
 default_features = false
 features = ["js", "automatic-room-key-forwarding"]
+branch = "release-for-crypto-wasm-12"
 
 [lints.rust]
 # Workaround for https://github.com/rustwasm/wasm-bindgen/issues/4283, while we work up the courage to upgrade

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-wasm",
-    "version": "12.0.0",
+    "version": "12.1.0",
     "homepage": "https://github.com/matrix-org/matrix-rust-sdk-wasm",
     "description": "WebAssembly bindings of the matrix-sdk-crypto encryption library",
     "license": "Apache-2.0",


### PR DESCRIPTION
For the fix for matrix-org/matrix-rust-sdk#4424 , to allow us to release without doing the more difficult work of adapting to the
changes in the latest matrix-rust-sdk.