### PR TITLE
Go back to depending on matrix-rust-sdk main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?branch=release-for-crypto-wasm-12#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
 dependencies = [
  "async-trait",
  "eyeball-im",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?branch=release-for-crypto-wasm-12#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
 dependencies = [
  "aes",
  "aquamarine",
@@ -1135,7 +1135,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?branch=release-for-crypto-wasm-12#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?branch=release-for-crypto-wasm-12#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1175,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?branch=release-for-crypto-wasm-12#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#37c17cf854a70fe6f719c7fde49a6b0e4402988f"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,9 @@ console_error_panic_hook = "0.1.7"
 futures-util = "0.3.27"
 http = "1.1.0"
 js-sys = "0.3.49"
-matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", features = ["js"], branch="release-for-crypto-wasm-12" }
-matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", default-features = false, features = ["e2e-encryption"], branch="release-for-crypto-wasm-12" }
-matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", optional = true, branch="release-for-crypto-wasm-12" }
+matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", features = ["js"] }
+matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", default-features = false, features = ["e2e-encryption"] }
+matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", optional = true }
 serde = "1.0.91"
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.5.0"
@@ -84,7 +84,6 @@ vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }
 git = "https://github.com/matrix-org/matrix-rust-sdk"
 default_features = false
 features = ["js", "automatic-room-key-forwarding"]
-branch = "release-for-crypto-wasm-12"
 
 [lints.rust]
 # Workaround for https://github.com/rustwasm/wasm-bindgen/issues/4283, while we work up the courage to upgrade


### PR DESCRIPTION
This undoes the change made in 0378300821d2aeca7d2f184141c864f2fc189051, except it stays on the same commit SHA of matrix-rust-sdk, but changes the branch specifier.

We temporarily switched to the branch `release-for-crypto-wasm-12` of `matrix-rust-sdk` to release 12.1.0 without needing to fix the other things needing work to get the latest `matrix-rust-sdk`. This change puts us back onto the main branch, as normal.