### PR TITLE
Fix typedoc warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "build": "WASM_PACK_ARGS=--release ./scripts/build.sh",
         "build:dev": "WASM_PACK_ARGS=--dev ./scripts/build.sh",
         "test": "jest --verbose && yarn run wasm-pack test --node",
-        "doc": "typedoc --tsconfig .",
+        "doc": "typedoc --treatWarningsAsErrors --tsconfig .",
         "prepack": "npm run build && npm run test"
     }
 }

--- a/src/libolm_migration.rs
+++ b/src/libolm_migration.rs
@@ -48,7 +48,7 @@ pub struct Migration {}
 
 /// The base dataset that is important to migrate to the Rust SDK.
 ///
-/// Can be imported into the rust store with {@link #migrateBaseData}.
+/// Can be imported into the rust store with {@link Migration::migrateBaseData}.
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Debug, Default)]
 pub struct BaseMigrationData {
@@ -103,7 +103,7 @@ impl Migration {
     /// Populates the user credentials, Olm account, backup data, etc. This is
     /// the first step in the migration process. Once this base data is
     /// imported, further data can be imported with {@link
-    /// #migrateOlmSessions}, {@link #migrateMegolmSessions}, and TODO room settings.
+    /// migrateOlmSessions}, {@link migrateMegolmSessions}, and TODO room settings.
     ///
     /// # Arguments
     ///
@@ -188,7 +188,7 @@ async fn migrate_base_data_to_store(
 ///
 /// Holds all the information that needs to be stored in a database to restore
 /// an Olm Session. Can be imported into the rust store with {@link
-/// #migrateOlmSessions}.
+/// Migration::migrateOlmSessions}.
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Debug)]
 pub struct PickledSession {
@@ -224,7 +224,7 @@ impl Migration {
     /// Migrate Olm sessions of a libolm-based setup to a vodozemac-based setup
     /// stored in an indexedDB crypto store.
     ///
-    /// Before this method can be used, {@link #migrateBaseData} must be used to
+    /// Before this method can be used, {@link migrateBaseData} must be used to
     /// import the base data into the crypto store.
     ///
     /// This method should be called a number of times, with separate batches of
@@ -378,7 +378,7 @@ impl Migration {
     /// Migrate Megolm sessions of a libolm-based setup to a vodozemac-based
     /// setup stored in an indexedDB crypto store.
     ///
-    /// Before this method can be used, {@link #migrateBaseData} must be used to
+    /// Before this method can be used, {@link migrateBaseData} must be used to
     /// import the base data into the crypto store.
     ///
     /// This method should be called a number of times, with separate batches of

--- a/src/libolm_migration.rs
+++ b/src/libolm_migration.rs
@@ -103,7 +103,8 @@ impl Migration {
     /// Populates the user credentials, Olm account, backup data, etc. This is
     /// the first step in the migration process. Once this base data is
     /// imported, further data can be imported with {@link
-    /// migrateOlmSessions}, {@link migrateMegolmSessions}, and TODO room settings.
+    /// migrateOlmSessions}, {@link migrateMegolmSessions}, and TODO room
+    /// settings.
     ///
     /// # Arguments
     ///

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -580,7 +580,7 @@ impl OlmMachine {
     /// keys will create a {@link OwnUserIdentity} and mark it as verified.
     ///
     /// The backup key will be persisted in the store and can be enabled using
-    /// the {@link BackupMachine}.
+    /// the BackupMachine.
     ///
     /// The provided `SecretsBundle` is freed by this method; be careful not to
     /// use it once this method has been called.
@@ -662,8 +662,8 @@ impl OlmMachine {
 
     /// Get the cross signing user identity of a user.
     ///
-    /// Returns a promise for an {@link identities.OwnUserIdentity}, a
-    /// {@link identities.OtherUserIdentity}, or `undefined`.
+    /// Returns a promise for an {@link OwnUserIdentity}, a
+    /// {@link OtherUserIdentity}, or `undefined`.
     #[wasm_bindgen(js_name = "getIdentity")]
     pub fn get_identity(&self, user_id: &identifiers::UserId) -> Promise {
         let me = self.inner.clone();
@@ -1191,7 +1191,7 @@ impl OlmMachine {
     /// trusted, otherwise we might be encrypting room keys that a malicious
     /// party could decrypt.
     ///
-    /// The {@link #verifyBackup} method can be used to do so.
+    /// The {@link verifyBackup} method can be used to do so.
     ///
     /// Returns `Promise<void>`.
     #[wasm_bindgen(js_name = "enableBackupV1")]
@@ -1513,7 +1513,7 @@ impl OlmMachine {
     /// This method will cause the sdk to generated outgoing secret requests
     /// (`m.secret.request`) to get the missing secrets. These requests will
     /// then be returned by a future call to {@link
-    /// OlmMachine#outgoing_requests}.
+    /// OlmMachine#outgoingRequests}.
     ///
     /// # Returns
     ///
@@ -1531,7 +1531,7 @@ impl OlmMachine {
     /// Get the stored room settings, such as the encryption algorithm or
     /// whether to encrypt only for trusted devices.
     ///
-    /// These settings can be modified via {@link #setRoomSettings}.
+    /// These settings can be modified via {@link setRoomSettings}.
     ///
     /// # Returns
     ///
@@ -1553,7 +1553,7 @@ impl OlmMachine {
     ///
     /// If the settings are valid, they will be persisted to the crypto store.
     /// These settings are not used directly by this library, but the saved
-    /// settings can be retrieved via {@link #getRoomSettings}.
+    /// settings can be retrieved via {@link getRoomSettings}.
     #[wasm_bindgen(js_name = "setRoomSettings")]
     pub async fn set_room_settings(
         &self,


### PR DESCRIPTION
```
/opt/homebrew/bin/yarn run doc
yarn run v1.22.22
$ typedoc --tsconfig .
[warning] Failed to resolve link to "#migrateBaseData" in comment for BaseMigrationData
[warning] Failed to resolve link to "#migrateOlmSessions" in comment for Migration.migrateBaseData
[warning] Failed to resolve link to "#migrateMegolmSessions" in comment for Migration.migrateBaseData
[warning] Failed to resolve link to "#migrateBaseData" in comment for Migration.migrateOlmSessions
[warning] Failed to resolve link to "#migrateBaseData" in comment for Migration.migrateMegolmSessions
[warning] Failed to resolve link to "BackupMachine" in comment for OlmMachine.importSecretsBundle
[warning] Failed to resolve link to "identities.OwnUserIdentity" in comment for OlmMachine.getIdentity
[warning] Failed to resolve link to "identities.OtherUserIdentity" in comment for OlmMachine.getIdentity
[warning] Failed to resolve link to "#verifyBackup" in comment for OlmMachine.enableBackupV1
[warning] Failed to resolve link to "OlmMachine#outgoing_requests" in comment for OlmMachine.requestMissingSecretsIfNeeded
[warning] Failed to resolve link to "#setRoomSettings" in comment for OlmMachine.getRoomSettings
[warning] Failed to resolve link to "#getRoomSettings" in comment for OlmMachine.setRoomSettings
[warning] Failed to resolve link to "#migrateOlmSessions" in comment for PickledSession
[info] html generated at ./docs
[warning] Found 0 errors and 13 warnings
✨  Done in 2.99s.

Process finished with exit code 0
```