### PR TITLE
Remove uses of `future_to_promise` in `machine.rs`

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -35,7 +35,6 @@ use crate::{
     dehydrated_devices::DehydratedDevices,
     device, encryption,
     error::MegolmDecryptionError,
-    future::{future_to_promise, future_to_promise_with_custom_error},
     identifiers, identities, olm, requests,
     requests::{outgoing_request_to_js_value, CrossSigningBootstrapRequests, ToDeviceRequest},
     responses::{self, response_from_string},
@@ -175,10 +174,9 @@ impl OlmMachine {
 
     /// Get the display name of our own device.
     #[wasm_bindgen(getter, js_name = "displayName")]
-    pub fn display_name(&self) -> Promise {
+    pub async fn display_name(&self) -> Result<Option<String>, JsError> {
         let me = self.inner.clone();
-
-        future_to_promise(async move { Ok(me.display_name().await?) })
+        Ok(me.display_name().await?)
     }
 
     /// Whether automatic transmission of room key requests is enabled.
@@ -220,16 +218,14 @@ impl OlmMachine {
     ///
     /// Returns a `Set<UserId>`.
     #[wasm_bindgen(js_name = "trackedUsers")]
-    pub fn tracked_users(&self) -> Result<Promise, JsError> {
+    pub async fn tracked_users(&self) -> Result<Set, JsError> {
         let set = Set::new(&JsValue::UNDEFINED);
         let me = self.inner.clone();
 
-        Ok(future_to_promise(async move {
-            for user in me.tracked_users().await? {
-                set.add(&identifiers::UserId::from(user).into());
-            }
-            Ok(set)
-        }))
+        for user in me.tracked_users().await? {
+            set.add(&identifiers::UserId::from(user).into());
+        }
+        Ok(set)
     }
 
     /// Update the list of tracked users.
@@ -253,15 +249,16 @@ impl OlmMachine {
     /// Items inside `users` will be invalidated by this method. Be careful not
     /// to use the `UserId`s after this method has been called.
     #[wasm_bindgen(js_name = "updateTrackedUsers")]
-    pub fn update_tracked_users(&self, users: Vec<identifiers::UserId>) -> Promise {
+    pub async fn update_tracked_users(
+        &self,
+        users: Vec<identifiers::UserId>,
+    ) -> Result<(), JsError> {
         let users = users.iter().map(|user| user.inner.clone()).collect::<Vec<_>>();
 
         let me = self.inner.clone();
 
-        future_to_promise(async move {
-            me.update_tracked_users(users.iter().map(AsRef::as_ref)).await?;
-            Ok(JsValue::UNDEFINED)
-        })
+        me.update_tracked_users(users.iter().map(AsRef::as_ref)).await?;
+        Ok(())
     }
 
     /// Mark all tracked users as dirty.
@@ -300,13 +297,13 @@ impl OlmMachine {
     ///
     /// A list of JSON strings, containing the decrypted to-device events.
     #[wasm_bindgen(js_name = "receiveSyncChanges")]
-    pub fn receive_sync_changes(
+    pub async fn receive_sync_changes(
         &self,
         to_device_events: &str,
         changed_devices: &sync_events::DeviceLists,
         one_time_keys_counts: &Map,
         unused_fallback_keys: Option<Set>,
-    ) -> Result<Promise, JsError> {
+    ) -> Result<String, JsError> {
         let to_device_events = serde_json::from_str(to_device_events)?;
         let changed_devices = changed_devices.inner.clone();
         let one_time_keys_counts: BTreeMap<OneTimeKeyAlgorithm, UInt> = one_time_keys_counts
@@ -337,24 +334,22 @@ impl OlmMachine {
 
         let me = self.inner.clone();
 
-        Ok(future_to_promise(async move {
-            // we discard the list of updated room keys in the result; JS applications are
-            // expected to use register_room_key_updated_callback to receive updated room
-            // keys.
-            let (decrypted_to_device_events, _) = me
-                .receive_sync_changes(EncryptionSyncChanges {
-                    to_device_events,
-                    changed_devices: &changed_devices,
-                    one_time_keys_counts: &one_time_keys_counts,
-                    unused_fallback_keys: unused_fallback_keys.as_deref(),
+        // we discard the list of updated room keys in the result; JS applications are
+        // expected to use register_room_key_updated_callback to receive updated room
+        // keys.
+        let (decrypted_to_device_events, _) = me
+            .receive_sync_changes(EncryptionSyncChanges {
+                to_device_events,
+                changed_devices: &changed_devices,
+                one_time_keys_counts: &one_time_keys_counts,
+                unused_fallback_keys: unused_fallback_keys.as_deref(),
 
-                    // matrix-sdk-crypto does not (currently) use `next_batch_token`.
-                    next_batch_token: None,
-                })
-                .await?;
+                // matrix-sdk-crypto does not (currently) use `next_batch_token`.
+                next_batch_token: None,
+            })
+            .await?;
 
-            Ok(serde_json::to_string(&decrypted_to_device_events)?)
-        }))
+        Ok(serde_json::to_string(&decrypted_to_device_events)?)
     }
 
     /// Get the outgoing requests that need to be sent out.
@@ -372,19 +367,16 @@ impl OlmMachine {
     /// responses need to be passed back to the state machine
     /// using {@link OlmMachine.markRequestAsSent}.
     #[wasm_bindgen(js_name = "outgoingRequests")]
-    pub fn outgoing_requests(&self) -> Promise {
+    pub async fn outgoing_requests(&self) -> Result<Array, JsError> {
         let me = self.inner.clone();
-
-        future_to_promise(async move {
-            Ok(me
-                .outgoing_requests()
-                .await?
-                .into_iter()
-                .map(outgoing_request_to_js_value)
-                .collect::<Result<Vec<JsValue>, _>>()?
-                .into_iter()
-                .collect::<Array>())
-        })
+        Ok(me
+            .outgoing_requests()
+            .await?
+            .into_iter()
+            .map(outgoing_request_to_js_value)
+            .collect::<Result<Vec<JsValue>, _>>()?
+            .into_iter()
+            .collect::<Array>())
     }
 
     /// Mark the request with the given request ID as sent (see
@@ -399,21 +391,19 @@ impl OlmMachine {
     /// * `response` represents the response that was received from the server
     ///   after the outgoing request was sent out.
     #[wasm_bindgen(js_name = "markRequestAsSent")]
-    pub fn mark_request_as_sent(
+    pub async fn mark_request_as_sent(
         &self,
         request_id: &str,
         request_type: requests::RequestType,
         response: &str,
-    ) -> Result<Promise, JsError> {
+    ) -> Result<bool, JsError> {
         let transaction_id = OwnedTransactionId::from(request_id);
         let response = response_from_string(response)?;
         let incoming_response = responses::OwnedResponse::try_from((request_type, response))?;
 
         let me = self.inner.clone();
-
-        Ok(future_to_promise(async move {
-            Ok(me.mark_request_as_sent(&transaction_id, &incoming_response).await.map(|_| true)?)
-        }))
+        me.mark_request_as_sent(&transaction_id, &incoming_response).await?;
+        Ok(true)
     }
 
     /// Encrypt a room message for the given room.
@@ -452,21 +442,19 @@ impl OlmMachine {
     /// Panics if a group session for the given room wasn't shared
     /// beforehand.
     #[wasm_bindgen(js_name = "encryptRoomEvent")]
-    pub fn encrypt_room_event(
+    pub async fn encrypt_room_event(
         &self,
         room_id: &identifiers::RoomId,
         event_type: String,
         content: &str,
-    ) -> Result<Promise, JsError> {
+    ) -> Result<String, JsError> {
         let room_id = room_id.inner.clone();
         let content = serde_json::from_str(content)?;
         let me = self.inner.clone();
 
-        Ok(future_to_promise(async move {
-            Ok(serde_json::to_string(
-                &me.encrypt_room_event_raw(&room_id, event_type.as_ref(), &content).await?,
-            )?)
-        }))
+        Ok(serde_json::to_string(
+            &me.encrypt_room_event_raw(&room_id, event_type.as_ref(), &content).await?,
+        )?)
     }
 
     /// Decrypt an event from a room timeline.
@@ -481,29 +469,22 @@ impl OlmMachine {
     /// A `Promise` which resolves to a {@link DecryptedRoomEvent} instance, or
     /// rejects with a {@link MegolmDecryptionError} instance.
     #[wasm_bindgen(js_name = "decryptRoomEvent")]
-    pub fn decrypt_room_event(
+    pub async fn decrypt_room_event(
         &self,
         event: &str,
         room_id: &identifiers::RoomId,
         decryption_settings: &encryption::DecryptionSettings,
-    ) -> Result<Promise, JsError> {
-        let event: Raw<_> = serde_json::from_str(event)?;
+    ) -> Result<responses::DecryptedRoomEvent, JsValue> {
+        // XXX: this isn't a `MegolmDecryptionError`, in conflict with the documentation
+        let event: Raw<_> = serde_json::from_str(event).map_err(JsError::from)?;
         let room_id = room_id.inner.clone();
         let decryption_settings = decryption_settings.into();
         let me = self.inner.clone();
 
-        Ok(future_to_promise_with_custom_error::<
-            _,
-            responses::DecryptedRoomEvent,
-            MegolmDecryptionError,
-        >(async move {
-            let room_event: TimelineEvent = me
-                .decrypt_room_event(&event, room_id.as_ref(), &decryption_settings)
-                .await
-                .map_err(MegolmDecryptionError::from)?
-                .into();
-            Ok(responses::DecryptedRoomEvent::from(room_event))
-        }))
+        match me.decrypt_room_event(&event, room_id.as_ref(), &decryption_settings).await {
+            Ok(event) => Ok(TimelineEvent::from(event).into()),
+            Err(err) => Err(MegolmDecryptionError::from(err).into()),
+        }
     }
 
     /// Get encryption info for a decrypted timeline event.
@@ -523,20 +504,16 @@ impl OlmMachine {
     ///
     /// {@link EncryptionInfo}
     #[wasm_bindgen(js_name = "getRoomEventEncryptionInfo")]
-    pub fn get_room_event_encryption_info(
+    pub async fn get_room_event_encryption_info(
         &self,
         event: &str,
         room_id: &identifiers::RoomId,
-    ) -> Result<Promise, JsError> {
+    ) -> Result<responses::EncryptionInfo, JsError> {
         let event: Raw<_> = serde_json::from_str(event)?;
         let room_id = room_id.inner.clone();
         let me = self.inner.clone();
 
-        Ok(future_to_promise(async move {
-            let encryption_info =
-                me.get_room_event_encryption_info(&event, room_id.as_ref()).await?;
-            Ok(responses::EncryptionInfo::from(encryption_info))
-        }))
+        Ok(me.get_room_event_encryption_info(&event, room_id.as_ref()).await?.into())
     }
 
     /// Get the status of the private cross signing keys.
@@ -544,12 +521,9 @@ impl OlmMachine {
     /// This can be used to check which private cross signing keys we
     /// have stored locally.
     #[wasm_bindgen(js_name = "crossSigningStatus")]
-    pub fn cross_signing_status(&self) -> Promise {
+    pub async fn cross_signing_status(&self) -> olm::CrossSigningStatus {
         let me = self.inner.clone();
-
-        future_to_promise::<_, olm::CrossSigningStatus>(async move {
-            Ok(me.cross_signing_status().await.into())
-        })
+        me.cross_signing_status().await.into()
     }
 
     /// Export all the secrets we have in the store into a {@link
@@ -595,15 +569,14 @@ impl OlmMachine {
     /// The export will contain the seeds for the ed25519 keys as
     /// unpadded base64 encoded strings.
     ///
-    /// Returns `null` if we don’t have any private cross signing keys;
+    /// Returns `undefined` if we don’t have any private cross signing keys;
     /// otherwise returns a `CrossSigningKeyExport`.
     #[wasm_bindgen(js_name = "exportCrossSigningKeys")]
-    pub fn export_cross_signing_keys(&self) -> Promise {
+    pub async fn export_cross_signing_keys(
+        &self,
+    ) -> Result<Option<store::CrossSigningKeyExport>, JsError> {
         let me = self.inner.clone();
-
-        future_to_promise(async move {
-            Ok(me.export_cross_signing_keys().await?.map(store::CrossSigningKeyExport::from))
-        })
+        Ok(me.export_cross_signing_keys().await?.map(Into::into))
     }
 
     /// Import our private cross signing keys.
@@ -612,12 +585,12 @@ impl OlmMachine {
     ///
     /// Returns a `CrossSigningStatus`.
     #[wasm_bindgen(js_name = "importCrossSigningKeys")]
-    pub fn import_cross_signing_keys(
+    pub async fn import_cross_signing_keys(
         &self,
         master_key: Option<String>,
         self_signing_key: Option<String>,
         user_signing_key: Option<String>,
-    ) -> Promise {
+    ) -> Result<olm::CrossSigningStatus, JsError> {
         let me = self.inner.clone();
         let export = matrix_sdk_crypto::store::CrossSigningKeyExport {
             master_key,
@@ -625,9 +598,7 @@ impl OlmMachine {
             user_signing_key,
         };
 
-        future_to_promise(async move {
-            Ok(me.import_cross_signing_keys(export).await.map(olm::CrossSigningStatus::from)?)
-        })
+        Ok(me.import_cross_signing_keys(export).await?.into())
     }
 
     /// Create a new cross signing identity and get the upload request
@@ -651,13 +622,13 @@ impl OlmMachine {
     ///
     /// Returns a {@link CrossSigningBootstrapRequests}.
     #[wasm_bindgen(js_name = "bootstrapCrossSigning")]
-    pub fn bootstrap_cross_signing(&self, reset: bool) -> Promise {
+    pub async fn bootstrap_cross_signing(
+        &self,
+        reset: bool,
+    ) -> Result<CrossSigningBootstrapRequests, JsError> {
         let me = self.inner.clone();
 
-        future_to_promise(async move {
-            let requests = me.bootstrap_cross_signing(reset).await?;
-            Ok(CrossSigningBootstrapRequests::try_from(requests)?)
-        })
+        Ok(me.bootstrap_cross_signing(reset).await?.try_into()?)
     }
 
     /// Get the cross signing user identity of a user.
@@ -665,28 +636,25 @@ impl OlmMachine {
     /// Returns a promise for an {@link OwnUserIdentity}, a
     /// {@link OtherUserIdentity}, or `undefined`.
     #[wasm_bindgen(js_name = "getIdentity")]
-    pub fn get_identity(&self, user_id: &identifiers::UserId) -> Promise {
+    pub async fn get_identity(&self, user_id: &identifiers::UserId) -> Result<JsValue, JsError> {
         let me = self.inner.clone();
         let user_id = user_id.inner.clone();
 
-        future_to_promise(async move {
-            // wait for up to a second for any in-flight device list requests to complete.
-            // The reason for this isn't so much to avoid races, but to make testing easier.
-            Ok(me
-                .get_identity(user_id.as_ref(), Some(Duration::from_secs(1)))
-                .await?
-                .map(identities::UserIdentity::from))
-        })
+        // wait for up to a second for any in-flight device list requests to complete.
+        // The reason for this isn't so much to avoid races, but to make testing easier.
+        Ok(me
+            .get_identity(user_id.as_ref(), Some(Duration::from_secs(1)))
+            .await?
+            .map(identities::UserIdentity::from)
+            .into())
     }
 
     /// Sign the given message using our device key and if available
     /// cross-signing master key.
-    pub fn sign(&self, message: String) -> Promise {
+    pub async fn sign(&self, message: String) -> Result<types::Signatures, JsError> {
         let me = self.inner.clone();
 
-        future_to_promise::<_, types::Signatures>(
-            async move { Ok(me.sign(&message).await?.into()) },
-        )
+        Ok(me.sign(&message).await?.into())
     }
 
     /// Invalidate the currently active outbound group session for the
@@ -695,11 +663,13 @@ impl OlmMachine {
     /// Returns true if a session was invalidated, false if there was
     /// no session to invalidate.
     #[wasm_bindgen(js_name = "invalidateGroupSession")]
-    pub fn invalidate_group_session(&self, room_id: &identifiers::RoomId) -> Promise {
+    pub async fn invalidate_group_session(
+        &self,
+        room_id: &identifiers::RoomId,
+    ) -> Result<bool, JsError> {
         let room_id = room_id.inner.clone();
         let me = self.inner.clone();
-
-        future_to_promise(async move { Ok(me.discard_room_key(&room_id).await?) })
+        Ok(me.discard_room_key(&room_id).await?)
     }
 
     /// Get to-device requests to share a room key with users in a room.
@@ -716,12 +686,12 @@ impl OlmMachine {
     /// Items inside `users` will be invalidated by this method. Be careful not
     /// to use the `UserId`s after this method has been called.
     #[wasm_bindgen(js_name = "shareRoomKey")]
-    pub fn share_room_key(
+    pub async fn share_room_key(
         &self,
         room_id: &identifiers::RoomId,
         users: Vec<identifiers::UserId>,
         encryption_settings: &encryption::EncryptionSettings,
-    ) -> Promise {
+    ) -> Result<Array, JsError> {
         let room_id = room_id.inner.clone();
         let users = users.iter().map(|user| user.inner.clone()).collect::<Vec<_>>();
         let encryption_settings =
@@ -729,21 +699,19 @@ impl OlmMachine {
 
         let me = self.inner.clone();
 
-        future_to_promise(async move {
-            let to_device_requests = me
-                .share_room_key(&room_id, users.iter().map(AsRef::as_ref), encryption_settings)
-                .await?;
+        let to_device_requests = me
+            .share_room_key(&room_id, users.iter().map(AsRef::as_ref), encryption_settings)
+            .await?;
 
-            // convert each request to our own ToDeviceRequest struct, and then wrap it in a
-            // JsValue.
-            //
-            // Then collect the results into a javascript Array, throwing any errors into
-            // the promise.
-            Ok(to_device_requests
-                .into_iter()
-                .map(|td| ToDeviceRequest::try_from(td.deref()).map(JsValue::from))
-                .collect::<Result<Array, _>>()?)
-        })
+        // convert each request to our own ToDeviceRequest struct, and then wrap it in a
+        // JsValue.
+        //
+        // Then collect the results into a javascript Array.
+        let result = to_device_requests
+            .into_iter()
+            .map(|td| ToDeviceRequest::try_from(td.deref()).map(JsValue::from))
+            .collect::<Result<_, _>>()?;
+        Ok(result)
     }
 
     /// Generate an "out-of-band" key query request for the given set of users.
@@ -769,10 +737,10 @@ impl OlmMachine {
         Ok(requests::KeysQueryRequest::try_from((request_id.to_string(), &request))?)
     }
 
-    /// Get the a key claiming request for the user/device pairs that
+    /// Get a key claiming request for the user/device pairs that
     /// we are missing Olm sessions for.
     ///
-    /// Returns `null` if no key claiming request needs to be sent
+    /// Returns `undefined` if no key claiming request needs to be sent
     /// out, otherwise it returns a `KeysClaimRequest` object.
     ///
     /// Sessions need to be established between devices so group
@@ -798,23 +766,24 @@ impl OlmMachine {
     /// Items inside `users` will be invalidated by this method. Be careful not
     /// to use the `UserId`s after this method has been called.
     #[wasm_bindgen(js_name = "getMissingSessions")]
-    pub fn get_missing_sessions(&self, users: Vec<identifiers::UserId>) -> Promise {
+    pub async fn get_missing_sessions(
+        &self,
+        users: Vec<identifiers::UserId>,
+    ) -> Result<Option<requests::KeysClaimRequest>, JsError> {
         let users = users.iter().map(|user| user.inner.clone()).collect::<Vec<_>>();
 
         let me = self.inner.clone();
 
-        future_to_promise(async move {
-            match me.get_missing_sessions(users.iter().map(AsRef::as_ref)).await? {
-                Some((transaction_id, keys_claim_request)) => {
-                    Ok(JsValue::from(requests::KeysClaimRequest::try_from((
-                        transaction_id.to_string(),
-                        &keys_claim_request,
-                    ))?))
-                }
+        let request = me.get_missing_sessions(users.iter().map(AsRef::as_ref)).await?;
 
-                None => Ok(JsValue::NULL),
-            }
-        })
+        Ok(request
+            .map(|(transaction_id, keys_claim_request)| {
+                requests::KeysClaimRequest::try_from((
+                    transaction_id.to_string(),
+                    &keys_claim_request,
+                ))
+            })
+            .transpose()?)
     }
 
     /// Get a map holding all the devices of a user.
@@ -834,19 +803,16 @@ impl OlmMachine {
     ///
     /// A {@link UserDevices} object.
     #[wasm_bindgen(js_name = "getUserDevices")]
-    pub fn get_user_devices(
+    pub async fn get_user_devices(
         &self,
         user_id: &identifiers::UserId,
         timeout_secs: Option<f64>,
-    ) -> Promise {
+    ) -> Result<device::UserDevices, JsError> {
         let user_id = user_id.inner.clone();
         let timeout_duration = timeout_secs.map(Duration::from_secs_f64);
 
         let me = self.inner.clone();
-
-        future_to_promise::<_, device::UserDevices>(async move {
-            Ok(me.get_user_devices(&user_id, timeout_duration).await.map(Into::into)?)
-        })
+        Ok(me.get_user_devices(&user_id, timeout_duration).await.map(Into::into)?)
     }
 
     /// Get a specific device of a user.
@@ -868,21 +834,18 @@ impl OlmMachine {
     ///
     /// If the device is known, a {@link Device}. Otherwise, `undefined`.
     #[wasm_bindgen(js_name = "getDevice")]
-    pub fn get_device(
+    pub async fn get_device(
         &self,
         user_id: &identifiers::UserId,
         device_id: &identifiers::DeviceId,
         timeout_secs: Option<f64>,
-    ) -> Promise {
+    ) -> Result<Option<device::Device>, JsError> {
         let user_id = user_id.inner.clone();
         let device_id = device_id.inner.clone();
         let timeout_duration = timeout_secs.map(Duration::from_secs_f64);
 
         let me = self.inner.clone();
-
-        future_to_promise::<_, Option<device::Device>>(async move {
-            Ok(me.get_device(&user_id, &device_id, timeout_duration).await?.map(Into::into))
-        })
+        Ok(me.get_device(&user_id, &device_id, timeout_duration).await?.map(Into::into))
     }
 
     /// Get a verification object for the given user ID with the given
@@ -932,20 +895,18 @@ impl OlmMachine {
     /// This method can be used to pass verification events that are happening
     /// in rooms to the `OlmMachine`. The event should be in the decrypted form.
     #[wasm_bindgen(js_name = "receiveVerificationEvent")]
-    pub fn receive_verification_event(
+    pub async fn receive_verification_event(
         &self,
         event: &str,
         room_id: &identifiers::RoomId,
-    ) -> Result<Promise, JsError> {
+    ) -> Result<(), JsError> {
         let room_id = room_id.inner.clone();
         let event: ruma::events::AnySyncMessageLikeEvent = serde_json::from_str(event)?;
         let event = event.into_full_event(room_id);
 
         let me = self.inner.clone();
 
-        Ok(future_to_promise(async move {
-            Ok(me.receive_verification_event(&event).await.map(|_| JsValue::UNDEFINED)?)
-        }))
+        Ok(me.receive_verification_event(&event).await?)
     }
 
     /// Export the keys that match the given predicate.
@@ -958,25 +919,27 @@ impl OlmMachine {
     /// Returns a Promise containing a Result containing a String which is a
     /// JSON-encoded array of ExportedRoomKey objects.
     #[wasm_bindgen(js_name = "exportRoomKeys")]
-    pub fn export_room_keys(&self, predicate: Function) -> Promise {
+    pub async fn export_room_keys(&self, predicate: Function) -> Result<String, JsError> {
         let me = self.inner.clone();
 
-        future_to_promise(async move {
-            stream_to_json_array(pin!(
-                me.store()
-                    .export_room_keys_stream(|session| {
-                        let session = session.clone();
+        let res = stream_to_json_array(pin!(
+            me.store()
+                .export_room_keys_stream(|session| {
+                    let session = session.clone();
 
-                        predicate
-                            .call1(&JsValue::NULL, &olm::InboundGroupSession::from(session).into())
-                            .expect("Predicate function passed to `export_room_keys` failed")
-                            .as_bool()
-                            .unwrap_or(false)
-                    })
-                    .await?,
-            ))
-            .await
-        })
+                    predicate
+                        .call1(&JsValue::NULL, &olm::InboundGroupSession::from(session).into())
+                        .expect("Predicate function passed to `export_room_keys` failed")
+                        .as_bool()
+                        .unwrap_or(false)
+                })
+                .await?,
+        ))
+        .await;
+
+        // custom conversion to JsError because anyhow::Error doesn't implement
+        // std::Error
+        res.map_err(|error| JsError::new(&error.to_string()))
     }
 
     /// Import the given room keys into our store.
@@ -993,25 +956,23 @@ impl OlmMachine {
     ///
     /// @deprecated Use `importExportedRoomKeys` or `importBackedUpRoomKeys`.
     #[wasm_bindgen(js_name = "importRoomKeys")]
-    pub fn import_room_keys(
+    pub async fn import_room_keys(
         &self,
         exported_room_keys: &str,
         progress_listener: Function,
-    ) -> Result<Promise, JsError> {
+    ) -> Result<String, JsError> {
         let me = self.inner.clone();
         let exported_room_keys = serde_json::from_str(exported_room_keys)?;
 
-        Ok(future_to_promise(async move {
-            let matrix_sdk_crypto::RoomKeyImportResult { imported_count, total_count, keys } =
-                Self::import_exported_room_keys_helper(&me, exported_room_keys, progress_listener)
-                    .await?;
+        let matrix_sdk_crypto::RoomKeyImportResult { imported_count, total_count, keys } =
+            Self::import_exported_room_keys_helper(&me, exported_room_keys, progress_listener)
+                .await?;
 
-            Ok(serde_json::to_string(&json!({
-                "imported_count": imported_count,
-                "total_count": total_count,
-                "keys": keys,
-            }))?)
-        }))
+        Ok(serde_json::to_string(&json!({
+            "imported_count": imported_count,
+            "total_count": total_count,
+            "keys": keys,
+        }))?)
     }
 
     /// Import the given room keys into our store.
@@ -1025,21 +986,17 @@ impl OlmMachine {
     ///
     /// Returns a {@link RoomKeyImportResult}.
     #[wasm_bindgen(js_name = "importExportedRoomKeys")]
-    pub fn import_exported_room_keys(
+    pub async fn import_exported_room_keys(
         &self,
         exported_room_keys: &str,
         progress_listener: Function,
-    ) -> Result<Promise, JsError> {
+    ) -> Result<RoomKeyImportResult, JsError> {
         let me = self.inner.clone();
         let exported_room_keys = serde_json::from_str(exported_room_keys)?;
 
-        Ok(future_to_promise(async move {
-            let result: RoomKeyImportResult =
-                Self::import_exported_room_keys_helper(&me, exported_room_keys, progress_listener)
-                    .await?
-                    .into();
-            Ok(result)
-        }))
+        Ok(Self::import_exported_room_keys_helper(&me, exported_room_keys, progress_listener)
+            .await?
+            .into())
     }
 
     /// Import the given room keys into our store.
@@ -1061,12 +1018,12 @@ impl OlmMachine {
     ///
     /// A {@link RoomKeyImportResult}.
     #[wasm_bindgen(js_name = "importBackedUpRoomKeys")]
-    pub fn import_backed_up_room_keys(
+    pub async fn import_backed_up_room_keys(
         &self,
         backed_up_room_keys: &Map,
         progress_listener: Option<Function>,
         backup_version: String,
-    ) -> Result<Promise, JsValue> {
+    ) -> Result<RoomKeyImportResult, JsValue> {
         let me = self.inner.clone();
 
         // convert the js-side data into rust data
@@ -1096,28 +1053,26 @@ impl OlmMachine {
             }
         }
 
-        Ok(future_to_promise(async move {
-            let result: RoomKeyImportResult = me
-                .store()
-                .import_room_keys(keys, Some(&backup_version), |progress, total_valid| {
-                    if let Some(callback) = &progress_listener {
-                        callback
-                            .call3(
-                                &JsValue::NULL,
-                                &JsValue::from(progress),
-                                // "total_valid" counts the total number of keys that
-                                // we passed to `import_backed_up_room_keys` so we
-                                // need to add `failures` to get the full total
-                                &JsValue::from(total_valid + failures),
-                                &JsValue::from(failures),
-                            )
-                            .expect("Progress listener passed to `importBackedUpRoomKeys` failed");
-                    }
-                })
-                .await?
-                .into();
-            Ok(result)
-        }))
+        let result = me
+            .store()
+            .import_room_keys(keys, Some(&backup_version), |progress, total_valid| {
+                if let Some(callback) = &progress_listener {
+                    callback
+                        .call3(
+                            &JsValue::NULL,
+                            &JsValue::from(progress),
+                            // "total_valid" counts the total number of keys that
+                            // we passed to `import_backed_up_room_keys` so we
+                            // need to add `failures` to get the full total
+                            &JsValue::from(total_valid + failures),
+                            &JsValue::from(failures),
+                        )
+                        .expect("Progress listener passed to `importBackedUpRoomKeys` failed");
+                }
+            })
+            .await
+            .map_err(JsError::from)?;
+        Ok(result.into())
     }
 
     /// Store the backup decryption key in the crypto store.
@@ -1127,32 +1082,27 @@ impl OlmMachine {
     ///
     /// Returns `Promise<void>`.
     #[wasm_bindgen(js_name = "saveBackupDecryptionKey")]
-    pub fn save_backup_decryption_key(
+    pub async fn save_backup_decryption_key(
         &self,
         decryption_key: &BackupDecryptionKey,
         version: String,
-    ) -> Promise {
+    ) -> Result<(), JsError> {
         let me = self.inner.clone();
         let inner_key = decryption_key.inner.clone();
 
-        future_to_promise(async move {
-            me.backup_machine().save_decryption_key(Some(inner_key), Some(version)).await?;
-            Ok(JsValue::UNDEFINED)
-        })
+        me.backup_machine().save_decryption_key(Some(inner_key), Some(version)).await?;
+        Ok(())
     }
 
     /// Get the backup keys we have saved in our store.
     /// Returns a `Promise` for {@link BackupKeys}.
     #[wasm_bindgen(js_name = "getBackupKeys")]
-    pub fn get_backup_keys(&self) -> Promise {
+    pub async fn get_backup_keys(&self) -> Result<BackupKeys, JsError> {
         let me = self.inner.clone();
-
-        future_to_promise(async move {
-            let inner = me.backup_machine().get_backup_keys().await?;
-            Ok(BackupKeys {
-                decryption_key: inner.decryption_key.map(|k| k.clone().into()),
-                backup_version: inner.backup_version,
-            })
+        let inner = me.backup_machine().get_backup_keys().await?;
+        Ok(BackupKeys {
+            decryption_key: inner.decryption_key.map(|k| k.clone().into()),
+            backup_version: inner.backup_version,
         })
     }
 
@@ -1174,15 +1124,16 @@ impl OlmMachine {
     ///
     /// Returns a {@link SignatureVerification} object.
     #[wasm_bindgen(js_name = "verifyBackup")]
-    pub fn verify_backup(&self, backup_info: JsValue) -> Result<Promise, JsError> {
+    pub async fn verify_backup(
+        &self,
+        backup_info: JsValue,
+    ) -> Result<SignatureVerification, JsError> {
         let backup_info: RoomKeyBackupInfo = serde_wasm_bindgen::from_value(backup_info)?;
 
         let me = self.inner.clone();
 
-        Ok(future_to_promise(async move {
-            let result = me.backup_machine().verify_backup(backup_info, false).await?;
-            Ok(SignatureVerification { inner: result })
-        }))
+        let result = me.backup_machine().verify_backup(backup_info, false).await?;
+        Ok(SignatureVerification { inner: result })
     }
 
     /// Activate the given backup key to be used with the given backup version.
@@ -1195,20 +1146,18 @@ impl OlmMachine {
     ///
     /// Returns `Promise<void>`.
     #[wasm_bindgen(js_name = "enableBackupV1")]
-    pub fn enable_backup_v1(
+    pub async fn enable_backup_v1(
         &self,
         public_key_base_64: String,
         version: String,
-    ) -> Result<Promise, JsError> {
+    ) -> Result<(), JsError> {
         let backup_key = MegolmV1BackupKey::from_base64(&public_key_base_64)?;
         backup_key.set_version(version);
 
         let me = self.inner.clone();
 
-        Ok(future_to_promise(async move {
-            me.backup_machine().enable_backup_v1(backup_key).await?;
-            Ok(JsValue::UNDEFINED)
-        }))
+        me.backup_machine().enable_backup_v1(backup_key).await?;
+        Ok(())
     }
 
     /// Are we able to encrypt room keys.
@@ -1218,13 +1167,9 @@ impl OlmMachine {
     ///
     /// Returns `Promise<bool>`.
     #[wasm_bindgen(js_name = "isBackupEnabled")]
-    pub fn is_backup_enabled(&self) -> Promise {
+    pub async fn is_backup_enabled(&self) -> bool {
         let me = self.inner.clone();
-
-        future_to_promise(async move {
-            let enabled = me.backup_machine().enabled().await;
-            Ok(JsValue::from_bool(enabled))
-        })
+        me.backup_machine().enabled().await
     }
 
     /// Disable and reset our backup state.
@@ -1234,13 +1179,10 @@ impl OlmMachine {
     ///
     /// Returns `Promise<void>`.
     #[wasm_bindgen(js_name = "disableBackup")]
-    pub fn disable_backup(&self) -> Promise {
+    pub async fn disable_backup(&self) -> Result<(), JsError> {
         let me = self.inner.clone();
-
-        future_to_promise(async move {
-            me.backup_machine().disable_backup().await?;
-            Ok(JsValue::UNDEFINED)
-        })
+        me.backup_machine().disable_backup().await?;
+        Ok(())
     }
 
     /// Encrypt a batch of room keys and return a request that needs to be sent
@@ -1248,31 +1190,28 @@ impl OlmMachine {
     ///
     /// Returns an optional {@link KeysBackupRequest}.
     #[wasm_bindgen(js_name = "backupRoomKeys")]
-    pub fn backup_room_keys(&self) -> Promise {
+    pub async fn backup_room_keys(&self) -> Result<Option<requests::KeysBackupRequest>, JsError> {
         let me = self.inner.clone();
 
-        future_to_promise(async move {
-            match me.backup_machine().backup().await? {
-                Some((transaction_id, keys_backup_request)) => {
-                    Ok(Some(requests::KeysBackupRequest::try_from((
-                        transaction_id.to_string(),
-                        &keys_backup_request,
-                    ))?))
-                }
-
-                None => Ok(None),
-            }
-        })
+        Ok(me
+            .backup_machine()
+            .backup()
+            .await?
+            .map(|(transaction_id, keys_backup_request)| {
+                requests::KeysBackupRequest::try_from((
+                    transaction_id.to_string(),
+                    &keys_backup_request,
+                ))
+            })
+            .transpose()?)
     }
 
     /// Get the number of backed up room keys and the total number of room keys.
     /// Returns a {@link RoomKeyCounts}.
     #[wasm_bindgen(js_name = "roomKeyCounts")]
-    pub fn room_key_counts(&self) -> Promise {
+    pub async fn room_key_counts(&self) -> Result<RoomKeyCounts, JsError> {
         let me = self.inner.clone();
-        future_to_promise::<_, RoomKeyCounts>(async move {
-            Ok(me.backup_machine().room_key_counts().await?.into())
-        })
+        Ok(me.backup_machine().room_key_counts().await?.into())
     }
 
     /// Encrypt the list of exported room keys using the given passphrase.
@@ -1473,17 +1412,15 @@ impl OlmMachine {
     /// If the secret is valid and handled, the secret inbox should be cleared
     /// by calling `delete_secrets_from_inbox`.
     #[wasm_bindgen(js_name = "getSecretsFromInbox")]
-    pub async fn get_secrets_from_inbox(&self, secret_name: String) -> Promise {
+    pub async fn get_secrets_from_inbox(&self, secret_name: String) -> Result<Set, JsError> {
         let set = Set::new(&JsValue::UNDEFINED);
         let me = self.inner.clone();
 
-        future_to_promise(async move {
-            let name = SecretName::from(secret_name);
-            for gossip in me.store().get_secrets_from_inbox(&name).await? {
-                set.add(&JsValue::from_str(&gossip.event.content.secret));
-            }
-            Ok(set)
-        })
+        let name = SecretName::from(secret_name);
+        for gossip in me.store().get_secrets_from_inbox(&name).await? {
+            set.add(&JsValue::from_str(&gossip.event.content.secret));
+        }
+        Ok(set)
     }
 
     /// Delete all secrets with the given secret name from the inbox.
@@ -1495,13 +1432,11 @@ impl OlmMachine {
     ///
     /// * `secret_name` - The name of the secret to delete.
     #[wasm_bindgen(js_name = "deleteSecretsFromInbox")]
-    pub async fn delete_secrets_from_inbox(&self, secret_name: String) -> Promise {
+    pub async fn delete_secrets_from_inbox(&self, secret_name: String) -> Result<(), JsError> {
         let me = self.inner.clone();
-        future_to_promise(async move {
-            let name = SecretName::from(secret_name);
-            me.store().delete_secrets_from_inbox(&name).await?;
-            Ok(JsValue::UNDEFINED)
-        })
+        let name = SecretName::from(secret_name);
+        me.store().delete_secrets_from_inbox(&name).await?;
+        Ok(())
     }
 
     /// Request missing local secrets from our other trusted devices.
@@ -1520,12 +1455,9 @@ impl OlmMachine {
     /// A `Promise` for a `bool` result, which will be true if  secrets were
     /// missing, and a request was generated.
     #[wasm_bindgen(js_name = "requestMissingSecretsIfNeeded")]
-    pub async fn request_missing_secrets_if_needed(&self) -> Promise {
+    pub async fn request_missing_secrets_if_needed(&self) -> Result<bool, JsError> {
         let me = self.inner.clone();
-        future_to_promise(async move {
-            let has_missing_secrets = me.query_missing_secrets_from_other_sessions().await?;
-            Ok(JsValue::from_bool(has_missing_secrets))
-        })
+        Ok(me.query_missing_secrets_from_other_sessions().await?)
     }
 
     /// Get the stored room settings, such as the encryption algorithm or

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -622,32 +622,32 @@ describe(OlmMachine.name, () => {
             });
 
             const decryptionSettings = new DecryptionSettings(TrustRequirement.Untrusted);
-            const decrypted = await m.decryptRoomEvent(stringifiedEvent, room, decryptionSettings);
-            expect(decrypted).toBeInstanceOf(DecryptedRoomEvent);
+            const decrypted = await m.decryptRoomEvent(stringifiedEvent, room, decryptionSettings)!;
+            expect(decrypted).toBeInstanceOf(DecryptedRoomEvent)
 
             const event = JSON.parse(decrypted.event);
             expect(event.content.msgtype).toStrictEqual("m.text");
             expect(event.content.body).toStrictEqual("Hello, World!");
 
-            expect(decrypted.sender.toString()).toStrictEqual(user.toString());
-            expect(decrypted.senderDevice.toString()).toStrictEqual(device.toString());
+            expect(decrypted.sender?.toString()).toStrictEqual(user.toString());
+            expect(decrypted.senderDevice?.toString()).toStrictEqual(device.toString());
             expect(decrypted.senderCurve25519Key).toBeDefined();
             expect(decrypted.senderClaimedEd25519Key).toBeDefined();
             expect(decrypted.forwardingCurve25519KeyChain).toHaveLength(0);
-            expect(decrypted.shieldState(true).color).toStrictEqual(ShieldColor.Red);
-            expect(decrypted.shieldState(true).code).toStrictEqual(ShieldStateCode.UnverifiedIdentity);
-            expect(decrypted.shieldState(false).color).toStrictEqual(ShieldColor.Red);
-            expect(decrypted.shieldState(false).code).toStrictEqual(ShieldStateCode.UnsignedDevice);
+            expect(decrypted.shieldState(true)?.color).toStrictEqual(ShieldColor.Red);
+            expect(decrypted.shieldState(true)?.code).toStrictEqual(ShieldStateCode.UnverifiedIdentity);
+            expect(decrypted.shieldState(false)?.color).toStrictEqual(ShieldColor.Red);
+            expect(decrypted.shieldState(false)?.code).toStrictEqual(ShieldStateCode.UnsignedDevice);
 
             const decryptionInfo = await m.getRoomEventEncryptionInfo(stringifiedEvent, room);
-            expect(decryptionInfo.sender.toString()).toStrictEqual(user.toString());
-            expect(decryptionInfo.senderDevice.toString()).toStrictEqual(device.toString());
+            expect(decryptionInfo.sender?.toString()).toStrictEqual(user.toString());
+            expect(decryptionInfo.senderDevice?.toString()).toStrictEqual(device.toString());
             expect(decryptionInfo.senderCurve25519Key).toBeDefined();
             expect(decryptionInfo.senderClaimedEd25519Key).toBeDefined();
-            expect(decryptionInfo.shieldState(true).color).toStrictEqual(ShieldColor.Red);
-            expect(decryptionInfo.shieldState(true).code).toStrictEqual(ShieldStateCode.UnverifiedIdentity);
-            expect(decryptionInfo.shieldState(false).color).toStrictEqual(ShieldColor.Red);
-            expect(decryptionInfo.shieldState(false).code).toStrictEqual(ShieldStateCode.UnsignedDevice);
+            expect(decryptionInfo.shieldState(true)?.color).toStrictEqual(ShieldColor.Red);
+            expect(decryptionInfo.shieldState(true)?.code).toStrictEqual(ShieldStateCode.UnverifiedIdentity);
+            expect(decryptionInfo.shieldState(false)?.color).toStrictEqual(ShieldColor.Red);
+            expect(decryptionInfo.shieldState(false)?.code).toStrictEqual(ShieldStateCode.UnsignedDevice);
         });
     });
 
@@ -696,9 +696,9 @@ describe(OlmMachine.name, () => {
         {
             const signature = signatures.get(user);
 
-            expect(signature.has("ed25519:foobar")).toStrictEqual(true);
+            expect(signature?.has("ed25519:foobar")).toStrictEqual(true);
 
-            const s = signature.get("ed25519:foobar");
+            const s = signature?.get("ed25519:foobar");
 
             expect(s).toBeInstanceOf(MaybeSignature);
 
@@ -715,7 +715,7 @@ describe(OlmMachine.name, () => {
         // `getSignature`
         {
             const signature = signatures.getSignature(user, new DeviceKeyId("ed25519:foobar"));
-            expect(signature.toBase64()).toStrictEqual(base64);
+            expect(signature?.toBase64()).toStrictEqual(base64);
         }
 
         // Unknown signatures.
@@ -1235,7 +1235,7 @@ describe(OlmMachine.name, () => {
 
             expect(await m.isBackupEnabled()).toStrictEqual(true);
 
-            let outgoing = await m.backupRoomKeys();
+            let outgoing = (await m.backupRoomKeys())!;
 
             expect(outgoing.id).toBeDefined();
             expect(outgoing.body).toBeDefined();
@@ -1271,7 +1271,7 @@ describe(OlmMachine.name, () => {
 
             let savedKey = await m.getBackupKeys();
 
-            expect(savedKey.decryptionKey.toBase64()).toStrictEqual(keyBackupKey.toBase64());
+            expect(savedKey.decryptionKey?.toBase64()).toStrictEqual(keyBackupKey.toBase64());
             expect(savedKey.decryptionKeyBase64).toStrictEqual(keyBackupKey.toBase64());
             expect(savedKey.backupVersion).toStrictEqual("3");
         });
@@ -1282,7 +1282,7 @@ describe(OlmMachine.name, () => {
             await m.shareRoomKey(room, [new UserId("@bob:example.org")], new EncryptionSettings());
             const keyBackupKey = BackupDecryptionKey.createRandomKey();
             await m.enableBackupV1(keyBackupKey.megolmV1PublicKey.publicKeyBase64, "1");
-            const outgoing = await m.backupRoomKeys();
+            const outgoing = (await m.backupRoomKeys())!;
             expect(outgoing.type).toStrictEqual(RequestType.KeysBackup);
 
             // Map from room ID, to map from session ID to the backup data.

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -623,7 +623,7 @@ describe(OlmMachine.name, () => {
 
             const decryptionSettings = new DecryptionSettings(TrustRequirement.Untrusted);
             const decrypted = await m.decryptRoomEvent(stringifiedEvent, room, decryptionSettings)!;
-            expect(decrypted).toBeInstanceOf(DecryptedRoomEvent)
+            expect(decrypted).toBeInstanceOf(DecryptedRoomEvent);
 
             const event = JSON.parse(decrypted.event);
             expect(event.content.msgtype).toStrictEqual("m.text");


### PR DESCRIPTION
Modern wasm_bindgen allows us just to write `async` functions, which is much more idiomatic, and gives better typescript types in the generated output.