### PR TITLE
Fix tsc errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from "./pkg/matrix_sdk_crypto_wasm";
+/*
+ * Re-export all the type definitions that wasm-bindgen generated for us.
+ *
+ * We do this by referring to a non-existent "matrix_sdk_crypto_wasm.js" file. This works because TSC will automatically
+ * transform this into the correct name "matrix_sdk_crypto_wasm.d.ts" [1].
+ *
+ * Other alternatives don't work:
+ *
+ *  - `export * from "./pkg/matrix_sdk_crypto_wasm.d.ts"`: You're not allowed to `import from "<foo>.d.ts"`
+ *    without `import type`, because normally, that would mean you don't get the runtime definitions that are in
+ *    "<foo>.js". This lint rule even applies to ".d.ts" files, which is arguably overzealous, but there you have it.
+ *
+ *  - `export type * from "./pkg/matrix_sdk_crypto_wasm.d.ts"`: Doing this means you can't call the constructors on any
+ *    of the exported types: `new RoomId(...)` gives a build error.
+ *
+ *  - `export * from "./pkg/matrix_sdk_crypto_wasm"`: This works in *some* environments, but in others, typescript
+ *    complains [2]. We could maybe get around this by mandating a `moduleResolution` setting of `bundler` or so, but
+ *    that is restrictive on our downstreams.
+ *
+ * A final alternative would be just to cat `matrix_sdk_crypto_wasm.d.ts` in here as part of the build script, but
+ * for now at least we're trying to avoid too much file manipulation.
+ *
+ * [1]: https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution
+ * [2]: https://www.typescriptlang.org/docs/handbook/modules/reference.html#extensionless-relative-paths
+ */
+export * from "./pkg/matrix_sdk_crypto_wasm.js";
 
 /**
  * Load the WebAssembly module in the background, if it has not already been loaded.


### PR DESCRIPTION
https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/201 introduced some build errors (and I forgot to check the CI afterwards). [Specifically](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/actions/runs/13261441394):

```
Module '"@matrix-org/matrix-sdk-crypto-wasm"' has no exported member 'DehydratedDeviceKey'.
```

... and similar.

The problem turns out to be that, given *certain* settings for tsc, it refuses to consider relative imports with no filename extension, and silently ignores the import. Yay.

Here is another go at fixing the import situation.

(Have I ever mentioned how much I hate the JS ecosystem? HOW CAN THIS BE SO HARD?)