### PR TITLE
Reintroduce stricter typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,3 +47,56 @@ export * from "./pkg/matrix_sdk_crypto_wasm.js";
  * @returns {Promise<void>}
  */
 export declare function initAsync(): Promise<void>;
+
+// The auto-generated typescript definitions are a good start, but could do with tightening up in a lot of areas.
+// The following is a manually-curated set of typescript definitions.
+declare module "./pkg/matrix_sdk_crypto_wasm.js" {
+    interface OlmMachine {
+        trackedUsers(): Promise<Set<any>>;
+        updateTrackedUsers(users: UserId[]): Promise<void>;
+        receiveSyncChanges(to_device_events: string, changed_devices: DeviceLists, one_time_keys_counts: Map<any, any>, unused_fallback_keys?: Set<any> | null): Promise<string>;
+        outgoingRequests(): Promise<Array<any>>;
+        markRequestAsSent(request_id: string, request_type: RequestType, response: string): Promise<boolean>;
+        encryptRoomEvent(room_id: RoomId, event_type: string, content: string): Promise<string>;
+        decryptRoomEvent(
+            event: string,
+            room_id: RoomId,
+            decryption_settings: DecryptionSettings,
+        ): Promise<DecryptedRoomEvent>;
+        getRoomEventEncryptionInfo(event: string, room_id: RoomId): Promise<EncryptionInfo>;
+        crossSigningStatus(): Promise<CrossSigningStatus>;
+        exportCrossSigningKeys(): Promise<CrossSigningKeyExport | undefined>;
+        importCrossSigningKeys(
+            master_key?: string | null,
+            self_signing_key?: string | null,
+            user_signing_key?: string | null,
+        ): Promise<CrossSigningStatus>;
+        bootstrapCrossSigning(reset: boolean): Promise<CrossSigningBootstrapRequests>;
+        sign(message: string): Promise<Signatures>;
+        invalidateGroupSession(room_id: RoomId): Promise<boolean>;
+        shareRoomKey(room_id: RoomId, users: UserId[], encryption_settings: EncryptionSettings): Promise<Array<any>>;
+        getMissingSessions(users: UserId[]): Promise<KeysClaimRequest | undefined>;
+        getUserDevices(user_id: UserId, timeout_secs?: number | null): Promise<UserDevices>;
+        getDevice(user_id: UserId, device_id: DeviceId, timeout_secs?: number | null): Promise<Device | undefined>;
+        receiveVerificationEvent(event: string, room_id: RoomId): Promise<void>;
+        exportRoomKeys(predicate: Function): Promise<string>;
+        importRoomKeys(exported_room_keys: string, progress_listener: Function): Promise<string>;
+        importExportedRoomKeys(exported_room_keys: string, progress_listener: Function): Promise<RoomKeyImportResult>;
+        importBackedUpRoomKeys(
+            backed_up_room_keys: Map<any, any>,
+            progress_listener: Function | null | undefined,
+            backup_version: string,
+        ): Promise<RoomKeyImportResult>;
+        saveBackupDecryptionKey(decryption_key: BackupDecryptionKey, version: string): Promise<void>;
+        getBackupKeys(): Promise<BackupKeys>;
+        verifyBackup(backup_info: any): Promise<SignatureVerification>;
+        enableBackupV1(public_key_base_64: string, version: string): Promise<void>;
+        isBackupEnabled(): Promise<boolean>;
+        disableBackup(): Promise<void>;
+        backupRoomKeys(): Promise<KeysBackupRequest | undefined>;
+        roomKeyCounts(): Promise<RoomKeyCounts>;
+        getSecretsFromInbox(secret_name: string): Promise<Set<any>>;
+        deleteSecretsFromInbox(secret_name: string): Promise<void>;
+        requestMissingSecretsIfNeeded(): Promise<boolean>;
+    }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,11 +51,26 @@ export declare function initAsync(): Promise<void>;
 // The auto-generated typescript definitions are a good start, but could do with tightening up in a lot of areas.
 // The following is a manually-curated set of typescript definitions.
 declare module "./pkg/matrix_sdk_crypto_wasm.js" {
+    /** The types returned by {@link OlmMachine.outgoingRequests}. */
+    type OutgoingRequest =
+        | KeysUploadRequest
+        | KeysQueryRequest
+        | KeysClaimRequest
+        | ToDeviceRequest
+        | SignatureUploadRequest
+        | RoomMessageRequest
+        | KeysBackupRequest;
+
     interface OlmMachine {
-        trackedUsers(): Promise<Set<any>>;
+        trackedUsers(): Promise<Set<UserId>>;
         updateTrackedUsers(users: UserId[]): Promise<void>;
-        receiveSyncChanges(to_device_events: string, changed_devices: DeviceLists, one_time_keys_counts: Map<any, any>, unused_fallback_keys?: Set<any> | null): Promise<string>;
-        outgoingRequests(): Promise<Array<any>>;
+        receiveSyncChanges(
+            to_device_events: string,
+            changed_devices: DeviceLists,
+            one_time_keys_counts: Map<string, number>,
+            unused_fallback_keys?: Set<string> | null,
+        ): Promise<string>;
+        outgoingRequests(): Promise<Array<OutgoingRequest>>;
         markRequestAsSent(request_id: string, request_type: RequestType, response: string): Promise<boolean>;
         encryptRoomEvent(room_id: RoomId, event_type: string, content: string): Promise<string>;
         decryptRoomEvent(


### PR DESCRIPTION
A partner to #205: the reverted PR gave some better typescript types. Rather than lose them altogether, we can replicate them manually.

A second commit adds a few more improvements.