### PR TITLE
Silence a cargo warning about default_features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }
 
 [dependencies.matrix-sdk-crypto]
 version = "0.10.0"
-default_features = false
+default-features = false
 features = ["js", "automatic-room-key-forwarding"]
 
 [lints.rust]


### PR DESCRIPTION
The default_features directive in the Cargo.toml file has been replaced by default-features.

This is shown as a warning currently but if we switch to Rust 2024 it will become an error, so let's just use the new variant.