### PR TITLE
Log warnings when we fail to parse a backed-up room key

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1082,16 +1082,17 @@ impl OlmMachine {
             for room_room_keys_entry in room_room_keys.entries() {
                 let room_room_keys_entry: Array = room_room_keys_entry?.dyn_into()?;
                 let session_id: JsString = room_room_keys_entry.get(0).dyn_into()?;
-                if let Ok(key) =
-                    serde_wasm_bindgen::from_value::<BackedUpRoomKey>(room_room_keys_entry.get(1))
+                match serde_wasm_bindgen::from_value::<BackedUpRoomKey>(room_room_keys_entry.get(1))
                 {
-                    keys.push(ExportedRoomKey::from_backed_up_room_key(
+                    Ok(key) => keys.push(ExportedRoomKey::from_backed_up_room_key(
                         room_id.clone(),
                         session_id.into(),
                         key,
-                    ));
-                } else {
-                    failures += 1;
+                    )),
+                    Err(e) => {
+                        failures += 1;
+                        warn!("Error parsing backed-up room key (session_id={session_id}): {e}");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Would have helped when debugging https://github.com/element-hq/element-web/issues/29878

Errors like this were made non-fatal in https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/85 but here we make them a little more visible.

Please review this carefully as I don't have any way to write tests for this code (right?).