### PR TITLE
Give all `ProcessedToDevice` variants a `rawEvent` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
     `ProcessedToDeviceEvent` instead of a JSON-encoded list of JSON-encoded events.
     This allows making the difference between an event that was sent in clear and
     the same event successfully decrypted.
-    ([#236](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/236))
+    ([#236](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/236)), ([#246](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/246))
 
 -   A number of the properties and methods on `DecryptedRoomEvent` no longer return `undefined`
     ([#243](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/243))

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -1643,7 +1643,7 @@ describe(OlmMachine.name, () => {
             const processed = receivedToDeviceArray[0];
             expect(processed.type).toEqual(ProcessedToDeviceEventType.PlainText);
             expect(processed).toBeInstanceOf(PlainTextToDeviceEvent);
-            const toDeviceEvent = JSON.parse((processed as PlainTextToDeviceEvent).rawEvent);
+            const toDeviceEvent = JSON.parse(processed.rawEvent);
 
             expect(toDeviceEvent.sender).toEqual("@alice:example.com");
             expect(toDeviceEvent.type).toEqual("custom.type");
@@ -1684,7 +1684,7 @@ describe(OlmMachine.name, () => {
             const processed = receivedToDeviceArray[0];
             expect(processed.type).toEqual(ProcessedToDeviceEventType.UnableToDecrypt);
             expect(processed).toBeInstanceOf(UTDToDeviceEvent);
-            const toDeviceEvent = JSON.parse((processed as UTDToDeviceEvent).wireEvent);
+            const toDeviceEvent = JSON.parse(processed.rawEvent);
 
             expect(toDeviceEvent.sender).toEqual("@bob:example.org");
             expect(toDeviceEvent.type).toEqual("m.room.encrypted");
@@ -1737,14 +1737,14 @@ describe(OlmMachine.name, () => {
             const processed0 = receivedToDeviceArray[0];
             expect(processed0.type).toEqual(ProcessedToDeviceEventType.Invalid);
             expect(processed0).toBeInstanceOf(InvalidToDeviceEvent);
-            const toDeviceEvent0 = JSON.parse((processed0 as InvalidToDeviceEvent).wireEvent);
+            const toDeviceEvent0 = JSON.parse(processed0.rawEvent);
             expect(toDeviceEvent0.sender).toEqual("@alice:example.com");
             expect(toDeviceEvent0.content).toBeDefined();
             expect(toDeviceEvent0.type).toBeUndefined();
 
             const processed1 = receivedToDeviceArray[1];
             expect(processed1.type).toEqual(ProcessedToDeviceEventType.Invalid);
-            const toDeviceEvent1 = JSON.parse((processed1 as InvalidToDeviceEvent).wireEvent);
+            const toDeviceEvent1 = JSON.parse(processed1.rawEvent);
             expect(toDeviceEvent1.sender).toEqual("@bob:example.org");
             expect(toDeviceEvent1.type).toEqual("m.room.encrypted");
         });
@@ -1846,7 +1846,7 @@ describe(OlmMachine.name, () => {
             const processed = receivedToDeviceArray[0];
             expect(processed.type).toEqual(ProcessedToDeviceEventType.Decrypted);
             expect(processed).toBeInstanceOf(DecryptedToDeviceEvent);
-            const toDeviceEvent = JSON.parse((processed as DecryptedToDeviceEvent).decryptedRawEvent);
+            const toDeviceEvent = JSON.parse(processed.rawEvent);
 
             expect(toDeviceEvent.sender).toEqual("@alice:example.org");
             expect(toDeviceEvent.type).toEqual("custom.type");


### PR DESCRIPTION
Turns out that being able to access our best guess as to the event content,
irrespective of the variant, is useful.

Follow-up on #236