### PR TITLE
Add state key to state event decryption test payload.

### DIFF
--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -689,6 +689,7 @@ describe(OlmMachine.name, () => {
                 origin_server_ts: Date.now(),
                 sender: user.toString(),
                 content: encrypted,
+                state_key: "m.room.topic:",
                 unsigned: {
                     age: 1234,
                 },


### PR DESCRIPTION
Tiny fix! 

- Adds `state_key` to the test payload, since the lack of this field was causing the event to fail verification.