### PR TITLE
Prepare sdk-crypto-wasm to use npm trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,7 @@ jobs:
           (cd xtask && cargo fmt -- --check)
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
-
-      - name: Install yarn
-        run: npm install --global yarn
+        uses: actions/setup-node@v5
 
       - name: Install dependencies
         run: yarn install
@@ -83,9 +80,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 24.0
-
-      - name: Install yarn
-        run: npm install --global yarn
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/latest-matrix-sdk-crypto.yml
+++ b/.github/workflows/latest-matrix-sdk-crypto.yml
@@ -63,9 +63,6 @@ jobs:
         with:
           node-version: 24.0
 
-      - name: Install yarn
-        run: npm install --global yarn
-
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,6 @@ jobs:
         with:
           node-version: 24.0
 
-      - name: Install yarn
-        run: npm install --global yarn
-
       - name: Install dependencies
         run: yarn install
 


### PR DESCRIPTION
Update to node 24 (and hence a sufficiently-recent npm), and request an
id-token from GHA.

https://github.com/element-hq/crypto-internal/issues/428