### PR TITLE
GH actions: remove lies about `git cliff`

### DIFF
--- a/.github/latest_matrix_sdk_failed_issue_template.md
+++ b/.github/latest_matrix_sdk_failed_issue_template.md
@@ -2,13 +2,3 @@
 title: Building matrix-rust-sdk-crypto-wasm against the latest matrix-sdk Rust is failing
 ---
 Something changed in [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk)'s crypto crate that will break the build of this repo (matrix-rust-sdk-crypto-wasm) when we update to it.
-
-To see the latest changes in matrix-sdk-crypto, use [git cliff](https://git-cliff.org/):
-
-```sh
-git cliff from_commit..to_commit
-```
-
-(You can see which commits to supply by running `cargo update matrix-sdk-common` in this repo and diffing `Cargo.lock`.)
-
-This should give you a hint about what changed.


### PR DESCRIPTION
The `latest-matrix-sdk-crypto` workflow opens a GH issue when this project fails to build against the current `main` of `matrix-rust-sdk`. The template it uses currently suggests you should use `git cliff` to find out what has changed.

The Rust SDK no longer uses `git cliff` to maintain its changelog. Your best bet is a regular `git diff`, but I'm sure I don't need to spell that out.