### PR TITLE
Update matrix-rust-sdk to 183116a4b1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,8 +1241,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-base"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f404a390ff98a73c426b1496b169be60ce6a93723a9a664e579d978a84c5e4"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=183116a4b1888039ad4d1714ac0d97f1375cc45a#183116a4b1888039ad4d1714ac0d97f1375cc45a"
 dependencies = [
  "as_variant",
  "async-trait",
@@ -1269,8 +1268,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fae2bdfc3d760d21a84d6d2036b5db5c48d9a3dee3794119e3fb9c4cc4ccc5"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=183116a4b1888039ad4d1714ac0d97f1375cc45a#183116a4b1888039ad4d1714ac0d97f1375cc45a"
 dependencies = [
  "eyeball-im",
  "futures-core",
@@ -1293,8 +1291,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304fc576810a9618bb831c4ad6403c758ec424f677668a49a196e3cde4b8f99f"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=183116a4b1888039ad4d1714ac0d97f1375cc45a#183116a4b1888039ad4d1714ac0d97f1375cc45a"
 dependencies = [
  "aes",
  "aquamarine",
@@ -1362,8 +1359,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6096084cc8d339c03e269ca25534d0f1e88d0097c35a215eb8c311797ec3e9"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=183116a4b1888039ad4d1714ac0d97f1375cc45a#183116a4b1888039ad4d1714ac0d97f1375cc45a"
 dependencies = [
  "async-trait",
  "base64",
@@ -1394,8 +1390,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1e7fb040be06f42e995288ef8b0990baa66febdb45a9f66f1d1c9d2d535dfe"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=183116a4b1888039ad4d1714ac0d97f1375cc45a#183116a4b1888039ad4d1714ac0d97f1375cc45a"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1407,8 +1402,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162a93e83114d5cef25c0ebaea72aa01b9f233df6ec4a2af45f175d01ec26323"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=183116a4b1888039ad4d1714ac0d97f1375cc45a#183116a4b1888039ad4d1714ac0d97f1375cc45a"
 dependencies = [
  "base64",
  "blake3",
@@ -1913,8 +1907,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "070c1de99c5b1fe78827abfce71b858104a2d1dae8f19029ee52cd876e8d2654"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "assign",
  "js_int",
@@ -1929,8 +1922,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2353d8d42b3aa0b58ed4187ef40fba3ed66d12c47201fd201803a122262985c"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "as_variant",
  "assign",
@@ -1953,8 +1945,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9223155004bd089d840d87a6b77dc17378657d0f597087eb0eb541a28c37e0"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "as_variant",
  "base64",
@@ -1987,8 +1978,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ad82efa481b458c37ed3bdf47404bd41c8611d15336da387a0dd1e0f088689"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -2012,8 +2002,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6dcd6e9823e177d15460d3cd3a413f38a2beea381f26aca1001c05cd6954ff"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -2024,8 +2013,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c6b5643060beec0fc9d7acfb41d2c5d91e1591db440ff62361d178e77c35fe"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "js_int",
  "thiserror",
@@ -2034,8 +2022,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffb3fa639bd851add9ca8a89200e6b8e00dd54cea9b21d39e8884e71e377633"
+source = "git+https://github.com/ruma/ruma?rev=a67081e402dce14365089b34f50489dacc9c53b5#a67081e402dce14365089b34f50489dacc9c53b5"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,9 @@ futures-util = "0.3.27"
 getrandom = { version = "0.3.0", features = ["wasm_js"] }
 http = "1.1.0"
 js-sys = "0.3.49"
-matrix-sdk-common = { features = ["js",  "experimental-encrypted-state-events"], version="0.16.0" }
-matrix-sdk-indexeddb = { default-features = false, features = ["e2e-encryption"], version="0.16.0" }
-matrix-sdk-qrcode = { optional = true, version="0.16.0" }
+matrix-sdk-common = { features = ["js",  "experimental-encrypted-state-events"], git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "183116a4b1888039ad4d1714ac0d97f1375cc45a" }
+matrix-sdk-indexeddb = { default-features = false, features = ["e2e-encryption"], git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "183116a4b1888039ad4d1714ac0d97f1375cc45a" }
+matrix-sdk-qrcode = { optional = true, git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "183116a4b1888039ad4d1714ac0d97f1375cc45a" }
 serde = "1.0.91"
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.6.5"
@@ -85,7 +85,8 @@ vergen-gitcl = { version = "1.0.0", features = ["build"] }
 [dependencies.matrix-sdk-crypto]
 default-features = false
 features = ["js", "automatic-room-key-forwarding", "experimental-encrypted-state-events"]
-version = "0.16.0"
+git = "https://github.com/matrix-org/matrix-rust-sdk"
+rev = "183116a4b1888039ad4d1714ac0d97f1375cc45a"
 
 [lints.rust]
 # Workaround for https://github.com/rustwasm/wasm-bindgen/issues/4283, while we work up the courage to upgrade

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -521,9 +521,19 @@ impl OlmMachine {
         let me = self.inner.clone();
 
         Ok(future_to_promise(async move {
-            Ok(serde_json::to_string(
-                &me.encrypt_room_event_raw(&room_id, event_type.as_ref(), &content).await?,
-            )?)
+            let encryption_result =
+                me.encrypt_room_event_raw(&room_id, event_type.as_ref(), &content).await?;
+
+            // Note: encryption_result contains EncryptionInfo that we discard here, but
+            // might conceivably be of interest to our callers in future.
+            //
+            // See https://github.com/matrix-org/matrix-rust-sdk/pull/5936 for the change that
+            // added this info.
+            //
+            // For now, we just return the event content, which preserves the same interface
+            // we had before.
+
+            Ok(serde_json::to_string(&encryption_result.content)?)
         }))
     }
 


### PR DESCRIPTION
and adapt encrypt_room_event to preserve its interface despite the change introduced in https://github.com/matrix-org/matrix-rust-sdk/pull/5936 .