### PR TITLE
Release v17.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
 
+# matrix-sdk-crypto-wasm v17.1.0
+
 -   Expose two new methods, `has_downloaded_all_room_keys` and `set_has_downloaded_all_room_keys`
     which allow clients to record whether they have downloaded all room keys from key backup for
     a particular room in advance of building an [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-wasm",
-    "version": "17.0.0",
+    "version": "17.1.0",
     "homepage": "https://github.com/matrix-org/matrix-rust-sdk-wasm",
     "description": "WebAssembly bindings of the matrix-sdk-crypto encryption library",
     "license": "Apache-2.0",


### PR DESCRIPTION
Bumping to include https://github.com/matrix-org/matrix-rust-sdk and https://github.com/matrix-org/matrix-rust-sdk/pull/6044 as part of https://github.com/matrix-org/matrix-rust-sdk/issues/5111.