### PR TITLE
Add a constructor for the MSC4388 version of the QrCodeData class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # UNRELEASED
 
 -   Add support for [MSC4388](https://github.com/matrix-org/matrix-spec-proposals/pull/4388) in the QrCodeData class.
-    ([#290](https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/290))
--   Update matrix-rust-sdk to `40c6c330`, which includes:
+    ([#290](https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/290)) ([#292](https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/292))
+-   Update matrix-rust-sdk to `0ec3db59`, which includes:
 
     -   Add MSC4388 support to the QrcodeData struct.
         ([#6089](https://github.com/matrix-org/matrix-rust-sdk/pull/6089))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,10 +399,6 @@ name = "decancer"
 version = "3.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9244323129647178bf41ac861a2cdb9d9c81b9b09d3d0d1de9cd302b33b8a1d"
-dependencies = [
- "lazy_static",
- "regex",
-]
 
 [[package]]
 name = "delegate-display"
@@ -1241,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-base"
 version = "0.16.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=40c6c330#40c6c330b05aa6aaea4c1507807d9e0c5f78da3d"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0ec3db59#0ec3db59f8ea882e4cbea076388ce36e3cd9faf3"
 dependencies = [
  "as_variant",
  "async-trait",
@@ -1268,7 +1264,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.16.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=40c6c330#40c6c330b05aa6aaea4c1507807d9e0c5f78da3d"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0ec3db59#0ec3db59f8ea882e4cbea076388ce36e3cd9faf3"
 dependencies = [
  "eyeball-im",
  "futures-core",
@@ -1291,7 +1287,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.16.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=40c6c330#40c6c330b05aa6aaea4c1507807d9e0c5f78da3d"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0ec3db59#0ec3db59f8ea882e4cbea076388ce36e3cd9faf3"
 dependencies = [
  "aes",
  "aquamarine",
@@ -1359,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.16.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=40c6c330#40c6c330b05aa6aaea4c1507807d9e0c5f78da3d"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0ec3db59#0ec3db59f8ea882e4cbea076388ce36e3cd9faf3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1390,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.16.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=40c6c330#40c6c330b05aa6aaea4c1507807d9e0c5f78da3d"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0ec3db59#0ec3db59f8ea882e4cbea076388ce36e3cd9faf3"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1402,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.16.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=40c6c330#40c6c330b05aa6aaea4c1507807d9e0c5f78da3d"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0ec3db59#0ec3db59f8ea882e4cbea076388ce36e3cd9faf3"
 dependencies = [
  "base64",
  "blake3",
@@ -1568,7 +1564,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
- "hmac",
 ]
 
 [[package]]
@@ -2532,18 +2527,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -2557,7 +2540,6 @@ dependencies = [
  "smallvec",
  "thread_local",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -2657,12 +2639,6 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vergen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,9 @@ futures-util = "0.3.27"
 getrandom = { version = "0.3.0", features = ["wasm_js"] }
 http = "1.1.0"
 js-sys = "0.3.49"
-matrix-sdk-common = { features = ["js",  "experimental-encrypted-state-events"], git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "40c6c330" }
-matrix-sdk-indexeddb = { default-features = false, features = ["e2e-encryption"], git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "40c6c330" }
-matrix-sdk-qrcode = { optional = true, git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "40c6c330" }
+matrix-sdk-common = { features = ["js",  "experimental-encrypted-state-events"], git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "0ec3db59" }
+matrix-sdk-indexeddb = { default-features = false, features = ["e2e-encryption"], git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "0ec3db59" }
+matrix-sdk-qrcode = { optional = true, git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "0ec3db59" }
 serde = "1.0.91"
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.6.5"
@@ -86,7 +86,7 @@ vergen-gitcl = { version = "1.0.0", features = ["build"] }
 default-features = false
 features = ["js", "automatic-room-key-forwarding", "experimental-encrypted-state-events"]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "40c6c330"
+rev = "0ec3db59"
 
 [lints.rust]
 # Workaround for https://github.com/rustwasm/wasm-bindgen/issues/4283, while we work up the courage to upgrade

--- a/src/qr_login.rs
+++ b/src/qr_login.rs
@@ -31,6 +31,15 @@ impl From<qr_login::QrCodeIntent> for QrCodeIntent {
     }
 }
 
+impl Into<qr_login::QrCodeIntent> for QrCodeIntent {
+    fn into(self) -> qr_login::QrCodeIntent {
+        match self {
+            QrCodeIntent::Login => qr_login::QrCodeIntent::Login,
+            QrCodeIntent::Reciprocate => qr_login::QrCodeIntent::Reciprocate,
+        }
+    }
+}
+
 /// Intent and MSC-specific data class for the QR code login support.
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
@@ -162,6 +171,27 @@ impl QrCodeData {
         };
 
         let inner = qr_login::QrCodeData::new_msc4108(public_key, rendezvous_url, intent_data);
+
+        Ok(QrCodeData { inner })
+    }
+
+    /// Create new {@link QrCodeData} from a given public key, a rendezvous ID
+    /// and, a base homeserver URL.
+    ///
+    /// This creates a QR code which conforms to
+    /// {@link https://github.com/matrix-org/matrix-spec-proposals/pull/4388 MSC4388} of the data
+    /// format for QR login.
+    pub fn new_msc4388(
+        public_key: Curve25519PublicKey,
+        rendezvous_id: String,
+        base_url: &str,
+        intent: QrCodeIntent,
+    ) -> Result<QrCodeData, JsError> {
+        let public_key = public_key.inner;
+        let intent = intent.into();
+        let base_url = Url::parse(base_url)?;
+
+        let inner = qr_login::QrCodeData::new_msc4388(public_key, rendezvous_id, base_url, intent);
 
         Ok(QrCodeData { inner })
     }


### PR DESCRIPTION
This PR bumps the SDK version again, but the only additional change is a new constructor for the [MSC4388](https://github.com/matrix-org/matrix-spec-proposals/pull/4388) QR code data format from: https://github.com/matrix-org/matrix-rust-sdk/pull/6124. Thus I reused the existing changelog entries.