### PR TITLE
README: fix broken docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Encryption](https://en.wikipedia.org/wiki/End-to-end_encryption)) for
         //
         // The following will use an in-memory store. It is recommended to use
         // indexedDB where that is available.
-        // See https://matrix-org.github.io/matrix-rust-sdk-crypto-wasm/classes/OlmMachine.html#initialize
+        // See https://matrix-org.github.io/matrix-sdk-crypto-wasm/classes/OlmMachine.html#initialize
         const olmMachine = await OlmMachine.initialize(new UserId(userId), new DeviceId(deviceId));
 
         return olmMachine;
     }
     ```
 
-    See the [API documentation](https://matrix-org.github.io/matrix-rust-sdk-crypto-wasm/) for more information.
+    See the [API documentation](https://matrix-org.github.io/matrix-sdk-crypto-wasm/) for more information.
 
 3. Build your project.
 


### PR DESCRIPTION
Fix some broken links to the hosted API docs.

These links seem to have been broken for a long time. https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/231 fixed one link, but there are more.