### PR TITLE
ci: Fixup release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,5 @@ jobs:
     steps:
       - name: Create the Github release
         run: gh release create "$GITHUB_REF_NAME" --draft
+        env:
+            GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The changes made in #303 did not pass `GH_TOKEN` to `gh` in the `release.yml` workflow.  This tiny PR fixes that. See [this failed run](https://github.com/matrix-org/matrix-sdk-crypto-wasm/actions/runs/22951044225/job/66615503057) of the release.