### PR TITLE
add missing checkout step in release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,11 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout the repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Create the Github release
         run: gh release create "$GITHUB_REF_NAME" --draft
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 
 -   Try to fix release script.
+    [#318](https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/318)
 
 # matrix-sdk-crypto-wasm v18.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
 
+-   Try to fix release script.
+
 # matrix-sdk-crypto-wasm v18.1.0
 
 -   Add `OlmMachine.pushSecretToVerifiedDevices` to support


### PR DESCRIPTION
The release currently fails with

```
gh release create "$GITHUB_REF_NAME" --draft
...
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

which I'm assuming is just because we're missing the checkout